### PR TITLE
input parameter output_wall_times added

### DIFF
--- a/include/adaflo/parameters.h
+++ b/include/adaflo/parameters.h
@@ -89,6 +89,7 @@ struct FlowParameters
   unsigned int output_verbosity;
   double       output_frequency;
   unsigned int print_solution_fields;
+  bool         output_wall_times;
 
   TimeStepping::Scheme time_step_scheme;
   double               start_time;

--- a/source/navier_stokes.cc
+++ b/source/navier_stokes.cc
@@ -92,9 +92,13 @@ NavierStokes<dim>::NavierStokes(
 
   // if we own the timer (not obtained from another class), reset
   // it. otherwise, just set the pointer
+  
   if (external_timer == 0)
+  {
+    const auto output_frequency = parameters.output_wall_times ? TimerOutput::summary : TimerOutput::never;
     timer =
-      std::make_shared<TimerOutput>(pcout, TimerOutput::summary, TimerOutput::wall_times);
+      std::make_shared<TimerOutput>(pcout, output_frequency, TimerOutput::wall_times);
+  }
   else
     timer.reset(external_timer, helpers::DummyDeleter<TimerOutput>());
 }

--- a/source/parameters.cc
+++ b/source/parameters.cc
@@ -231,6 +231,10 @@ FlowParameters::declare_parameters(ParameterHandler &prm)
                     Patterns::Integer(),
                     "defines whether to output vtk files with the "
                     "whole solution field or just collected point data");
+  prm.declare_entry("output wall_times",
+                    "0",
+                    Patterns::Integer(),
+                    "Defines whether to output wall times. 0 means no output.");
   prm.leave_subsection();
 
   prm.enter_subsection("Two phase");
@@ -502,6 +506,7 @@ FlowParameters::parse_parameters(const std::string parameter_file, ParameterHand
   print_solution_fields = prm.get_integer("output vtk files");
   if (print_solution_fields > 2)
     print_solution_fields = 1;
+  output_wall_times      = prm.get_integer("output wall times") > 0;
   prm.leave_subsection();
 
 

--- a/source/parameters.cc
+++ b/source/parameters.cc
@@ -231,7 +231,7 @@ FlowParameters::declare_parameters(ParameterHandler &prm)
                     Patterns::Integer(),
                     "defines whether to output vtk files with the "
                     "whole solution field or just collected point data");
-  prm.declare_entry("output wall_times",
+  prm.declare_entry("output wall times",
                     "0",
                     Patterns::Integer(),
                     "Defines whether to output wall times. 0 means no output.");

--- a/source/two_phase_base.cc
+++ b/source/two_phase_base.cc
@@ -66,7 +66,7 @@ TwoPhaseBaseAlgorithm<dim>::TwoPhaseBaseAlgorithm(
   TimerOutput *                              timer_in)
   : pcout(std::cout, Utilities::MPI::this_mpi_process(tria_in.get_communicator()) == 0)
   , timer((timer_in == 0 ?
-             new TimerOutput(pcout, TimerOutput::summary, TimerOutput::wall_times) :
+             new TimerOutput(pcout, parameters_in.output_wall_times ? TimerOutput::summary : TimerOutput::never, TimerOutput::wall_times) :
              timer_in),
           helpers::DummyDeleter<TimerOutput>(timer_in == 0))
   , triangulation(tria_in)


### PR DESCRIPTION
With this PR I am suggesting to introduce a parameter `output_wall_times` to control whether the wall time summary is printed. This is necessary in particular for running tests.