### PR TITLE
Do not try to clear external matrix-free

### DIFF
--- a/source/navier_stokes.cc
+++ b/source/navier_stokes.cc
@@ -109,8 +109,6 @@ NavierStokes<dim>::NavierStokes(
 template <int dim>
 NavierStokes<dim>::~NavierStokes()
 {
-  if (matrix_free != 0)
-    matrix_free->clear();
   solver_memory.release_unused_memory();
   GrowingVectorMemory<
     LinearAlgebra::distributed::Vector<double>>::release_unused_memory();


### PR DESCRIPTION
This happens because we only add an internal pointer to the class which can get deallocated in the outside. For example the `TwoPhaseBaseAlgorithm` holds the `MatrixFree` objects and deallocates it before its base class, `NavierStokes`, calls this check. But there really is no need to do anything here as we have properly released everything already.