### PR TITLE
Introduce dof_index_u, dof_index_p, quad_index_u, quad_index_p in NS

### DIFF
--- a/include/adaflo/navier_stokes.h
+++ b/include/adaflo/navier_stokes.h
@@ -46,6 +46,11 @@ template <int dim>
 class NavierStokes : public FlowBaseAlgorithm<dim>
 {
 public:
+  static const unsigned int dof_index_u  = 0;
+  static const unsigned int dof_index_p  = 1;
+  static const unsigned int quad_index_u = 0;
+  static const unsigned int quad_index_p = 1;
+
   NavierStokes(const Mapping<dim> &                              mapping,
                const FlowParameters &                            parameters,
                Triangulation<dim> &                              triangulation,

--- a/include/adaflo/navier_stokes.h
+++ b/include/adaflo/navier_stokes.h
@@ -46,10 +46,10 @@ template <int dim>
 class NavierStokes : public FlowBaseAlgorithm<dim>
 {
 public:
-  static const unsigned int dof_index_u  = 0;
-  static const unsigned int dof_index_p  = 1;
-  static const unsigned int quad_index_u = 0;
-  static const unsigned int quad_index_p = 1;
+  unsigned int dof_index_u  = 0;
+  unsigned int dof_index_p  = 1;
+  unsigned int quad_index_u = 0;
+  unsigned int quad_index_p = 1;
 
   NavierStokes(const Mapping<dim> &                              mapping,
                const FlowParameters &                            parameters,
@@ -99,7 +99,11 @@ public:
     const Function<dim> &initial_velocity_field,
     const Function<dim> &initial_distance_function = Functions::ZeroFunction<dim>());
   void
-  initialize_matrix_free(MatrixFree<dim> *external_matrix_free = 0);
+  initialize_matrix_free(MatrixFree<dim> *  external_matrix_free = 0,
+                         const unsigned int dof_index_u          = 0,
+                         const unsigned int dof_index_p          = 1,
+                         const unsigned int quad_index_u         = 0,
+                         const unsigned int quad_index_p         = 1);
 
   void
   init_time_advance(const bool print_time_info = true);

--- a/include/adaflo/navier_stokes_matrix.h
+++ b/include/adaflo/navier_stokes_matrix.h
@@ -55,10 +55,10 @@ public:
     velocity_stored;
   NavierStokesMatrix(
     const FlowParameters &                                 parameters,
-    const unsigned int                                     dof_index_u,
-    const unsigned int                                     dof_index_p,
-    const unsigned int                                     quad_index_u,
-    const unsigned int                                     quad_index_p,
+    const unsigned int &                                   dof_index_u,
+    const unsigned int &                                   dof_index_p,
+    const unsigned int &                                   quad_index_u,
+    const unsigned int &                                   quad_index_p,
     const LinearAlgebra::distributed::BlockVector<double> &solution_old,
     const LinearAlgebra::distributed::BlockVector<double> &solution_old_old);
 
@@ -248,10 +248,10 @@ private:
   const FlowParameters & parameters;
 
 public:
-  const unsigned int dof_index_u;
-  const unsigned int dof_index_p;
-  const unsigned int quad_index_u;
-  const unsigned int quad_index_p;
+  const unsigned int &dof_index_u;
+  const unsigned int &dof_index_p;
+  const unsigned int &quad_index_u;
+  const unsigned int &quad_index_p;
 
 private:
   mutable AlignedVector<VectorizedArray<double>> variable_densities;

--- a/include/adaflo/navier_stokes_matrix.h
+++ b/include/adaflo/navier_stokes_matrix.h
@@ -247,11 +247,13 @@ private:
   const TimeStepping *   time_stepping;
   const FlowParameters & parameters;
 
+public:
   const unsigned int dof_index_u;
   const unsigned int dof_index_p;
   const unsigned int quad_index_u;
   const unsigned int quad_index_p;
 
+private:
   mutable AlignedVector<VectorizedArray<double>> variable_densities;
   mutable AlignedVector<VectorizedArray<double>> variable_viscosities;
   mutable AlignedVector<velocity_stored>         linearized_velocities;

--- a/include/adaflo/navier_stokes_matrix.h
+++ b/include/adaflo/navier_stokes_matrix.h
@@ -55,6 +55,10 @@ public:
     velocity_stored;
   NavierStokesMatrix(
     const FlowParameters &                                 parameters,
+    const unsigned int                                     dof_index_u,
+    const unsigned int                                     dof_index_p,
+    const unsigned int                                     quad_index_u,
+    const unsigned int                                     quad_index_p,
     const LinearAlgebra::distributed::BlockVector<double> &solution_old,
     const LinearAlgebra::distributed::BlockVector<double> &solution_old_old);
 
@@ -69,31 +73,31 @@ public:
   unsigned int
   n_dofs_p() const
   {
-    return matrix_free->get_dof_handler(1).n_dofs();
+    return matrix_free->get_dof_handler(dof_index_p).n_dofs();
   }
 
   void
   initialize_u_vector(LinearAlgebra::distributed::Vector<double> &vec) const
   {
-    matrix_free->initialize_dof_vector(vec, 0);
+    matrix_free->initialize_dof_vector(vec, dof_index_u);
   }
 
   void
   initialize_p_vector(LinearAlgebra::distributed::Vector<double> &vec) const
   {
-    matrix_free->initialize_dof_vector(vec, 1);
+    matrix_free->initialize_dof_vector(vec, dof_index_p);
   }
 
   unsigned int
   n_dofs_u() const
   {
-    return matrix_free->get_dof_handler(0).n_dofs();
+    return matrix_free->get_dof_handler(dof_index_u).n_dofs();
   }
 
   unsigned int
   pressure_degree() const
   {
-    return matrix_free->get_dof_handler(1).get_fe().degree;
+    return matrix_free->get_dof_handler(dof_index_p).get_fe().degree;
   }
 
   const MatrixFree<dim> &
@@ -239,9 +243,15 @@ private:
     const unsigned int &,
     const std::pair<unsigned int, unsigned int> &cell_range) const;
 
-  const MatrixFree<dim> *                        matrix_free;
-  const TimeStepping *                           time_stepping;
-  const FlowParameters &                         parameters;
+  const MatrixFree<dim> *matrix_free;
+  const TimeStepping *   time_stepping;
+  const FlowParameters & parameters;
+
+  const unsigned int dof_index_u;
+  const unsigned int dof_index_p;
+  const unsigned int quad_index_u;
+  const unsigned int quad_index_p;
+
   mutable AlignedVector<VectorizedArray<double>> variable_densities;
   mutable AlignedVector<VectorizedArray<double>> variable_viscosities;
   mutable AlignedVector<velocity_stored>         linearized_velocities;
@@ -273,8 +283,9 @@ NavierStokesMatrix<dim>::begin_densities(const unsigned int macro_cell) const
 {
   AssertIndexRange(macro_cell, matrix_free->n_cell_batches());
   AssertDimension(variable_densities.size(),
-                  matrix_free->n_cell_batches() * matrix_free->get_n_q_points(0));
-  return &variable_densities[matrix_free->get_n_q_points(0) * macro_cell];
+                  matrix_free->n_cell_batches() *
+                    matrix_free->get_n_q_points(quad_index_u));
+  return &variable_densities[matrix_free->get_n_q_points(quad_index_u) * macro_cell];
 }
 
 
@@ -285,8 +296,9 @@ NavierStokesMatrix<dim>::begin_densities(const unsigned int macro_cell)
 {
   AssertIndexRange(macro_cell, matrix_free->n_cell_batches());
   AssertDimension(variable_densities.size(),
-                  matrix_free->n_cell_batches() * matrix_free->get_n_q_points(0));
-  return &variable_densities[matrix_free->get_n_q_points(0) * macro_cell];
+                  matrix_free->n_cell_batches() *
+                    matrix_free->get_n_q_points(quad_index_u));
+  return &variable_densities[matrix_free->get_n_q_points(quad_index_u) * macro_cell];
 }
 
 
@@ -297,8 +309,9 @@ NavierStokesMatrix<dim>::begin_viscosities(const unsigned int macro_cell) const
 {
   AssertIndexRange(macro_cell, matrix_free->n_cell_batches());
   AssertDimension(variable_viscosities.size(),
-                  matrix_free->n_cell_batches() * matrix_free->get_n_q_points(0));
-  return &variable_viscosities[matrix_free->get_n_q_points(0) * macro_cell];
+                  matrix_free->n_cell_batches() *
+                    matrix_free->get_n_q_points(quad_index_u));
+  return &variable_viscosities[matrix_free->get_n_q_points(quad_index_u) * macro_cell];
 }
 
 
@@ -309,8 +322,9 @@ NavierStokesMatrix<dim>::begin_viscosities(const unsigned int macro_cell)
 {
   AssertIndexRange(macro_cell, matrix_free->n_cell_batches());
   AssertDimension(variable_viscosities.size(),
-                  matrix_free->n_cell_batches() * matrix_free->get_n_q_points(0));
-  return &variable_viscosities[matrix_free->get_n_q_points(0) * macro_cell];
+                  matrix_free->n_cell_batches() *
+                    matrix_free->get_n_q_points(quad_index_u));
+  return &variable_viscosities[matrix_free->get_n_q_points(quad_index_u) * macro_cell];
 }
 
 
@@ -333,8 +347,9 @@ NavierStokesMatrix<dim>::begin_linearized_velocities(const unsigned int macro_ce
 
   AssertIndexRange(macro_cell, matrix_free->n_cell_batches());
   AssertDimension(linearized_velocities.size(),
-                  matrix_free->n_cell_batches() * matrix_free->get_n_q_points(0));
-  return &linearized_velocities[matrix_free->get_n_q_points(0) * macro_cell];
+                  matrix_free->n_cell_batches() *
+                    matrix_free->get_n_q_points(quad_index_u));
+  return &linearized_velocities[matrix_free->get_n_q_points(quad_index_u) * macro_cell];
 }
 
 

--- a/include/adaflo/navier_stokes_preconditioner.h
+++ b/include/adaflo/navier_stokes_preconditioner.h
@@ -57,11 +57,14 @@ namespace dealii
 } // namespace dealii
 
 template <int dim>
+class NavierStokes;
+
+template <int dim>
 class NavierStokesPreconditioner
 {
 public:
   NavierStokesPreconditioner(const FlowParameters &           parameters,
-                             const FlowBaseAlgorithm<dim> &   base_algorithm,
+                             const NavierStokes<dim> &        base_algorithm,
                              const Triangulation<dim> &       tria,
                              const AffineConstraints<double> &constraints_u);
 
@@ -211,8 +214,8 @@ private:
 
   IntegrationHelper integration_helper;
 
-  const FlowParameters &        parameters;
-  const FlowBaseAlgorithm<dim> &flow_algorithm;
+  const FlowParameters &   parameters;
+  const NavierStokes<dim> &flow_algorithm;
 
   // A table containing variable densities on faces for face integrals in
   // augmented Taylor--Hood

--- a/source/navier_stokes.cc
+++ b/source/navier_stokes.cc
@@ -388,8 +388,17 @@ NavierStokes<dim>::setup_problem(const Function<dim> &initial_velocity_field,
 
 template <int dim>
 void
-NavierStokes<dim>::initialize_matrix_free(MatrixFree<dim> *external_matrix_free)
+NavierStokes<dim>::initialize_matrix_free(MatrixFree<dim> *  external_matrix_free,
+                                          const unsigned int dof_index_u,
+                                          const unsigned int dof_index_p,
+                                          const unsigned int quad_index_u,
+                                          const unsigned int quad_index_p)
 {
+  this->dof_index_u  = dof_index_u;
+  this->dof_index_p  = dof_index_p;
+  this->quad_index_u = quad_index_u;
+  this->quad_index_p = quad_index_p;
+
   if (external_matrix_free != 0)
     {
       matrix_free.reset(const_cast<MatrixFree<dim> *>(external_matrix_free),

--- a/source/navier_stokes_matrix.cc
+++ b/source/navier_stokes_matrix.cc
@@ -601,12 +601,13 @@ NavierStokesMatrix<dim>::local_operation(
 {
   typedef VectorizedArray<double>                                            vector_t;
   FEEvaluation<dim, degree_p == -1 ? -1 : (degree_p + 1), degree_p + 2, dim> velocity(
-    data, 0);
-  FEEvaluation<dim, degree_p, degree_p + 2, 1> pressure(data, 1);
+    data, dof_index_u, quad_index_u);
+  FEEvaluation<dim, degree_p, degree_p + 2, 1> pressure(data, dof_index_p, quad_index_u);
 
-  FEEvaluation<dim, degree_p == -1 ? -1 : (degree_p + 1), degree_p + 2, dim> old(data, 0);
-  FEEvaluation<dim, degree_p == -1 ? -1 : (degree_p + 1), degree_p + 2, dim> old_old(data,
-                                                                                     0);
+  FEEvaluation<dim, degree_p == -1 ? -1 : (degree_p + 1), degree_p + 2, dim> old(
+    data, dof_index_u, quad_index_u);
+  FEEvaluation<dim, degree_p == -1 ? -1 : (degree_p + 1), degree_p + 2, dim> old_old(
+    data, dof_index_u, quad_index_u);
 
   // get variables for the time step
   const vector_t time_step_weight = make_vectorized_array<double>(
@@ -885,8 +886,8 @@ NavierStokesMatrix<dim>::local_divergence(
   const std::pair<unsigned int, unsigned int> &     cell_range) const
 {
   FEEvaluation<dim, degree_p == -1 ? -1 : (degree_p + 1), degree_p + 2, dim> velocity(
-    data, 0);
-  FEEvaluation<dim, degree_p, degree_p + 2, 1> pressure(data, 1);
+    data, dof_index_u, quad_index_u);
+  FEEvaluation<dim, degree_p, degree_p + 2, 1> pressure(data, dof_index_p, quad_index_u);
 
   const VectorizedArray<double> *mu_values =
     variable_viscosities.empty() ? 0 : begin_viscosities(cell_range.first);
@@ -937,7 +938,9 @@ NavierStokesMatrix<dim>::local_pressure_poisson(
   if (use_variable_coefficients &&
       parameters.physical_type != FlowParameters::incompressible_stationary)
     {
-      FEEvaluation<dim, degree_p, degree_p + 2, 1> pressure(data, 1, 0);
+      FEEvaluation<dim, degree_p, degree_p + 2, 1> pressure(data,
+                                                            dof_index_p,
+                                                            quad_index_u);
 
       for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
         {
@@ -957,7 +960,9 @@ NavierStokesMatrix<dim>::local_pressure_poisson(
     }
   else
     {
-      FEEvaluation<dim, degree_p, degree_p + 1, 1> pressure(data, 1, 1);
+      FEEvaluation<dim, degree_p, degree_p + 1, 1> pressure(data,
+                                                            dof_index_p,
+                                                            quad_index_p);
 
       for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
         {
@@ -997,7 +1002,7 @@ NavierStokesMatrix<dim>::local_pressure_mass(
   const std::pair<unsigned int, unsigned int> &     cell_range) const
 {
   typedef VectorizedArray<double>              vector_t;
-  FEEvaluation<dim, degree_p, degree_p + 1, 1> pressure(data, 1, 1);
+  FEEvaluation<dim, degree_p, degree_p + 1, 1> pressure(data, dof_index_p, quad_index_p);
 
   const bool use_variable_coefficients = variable_viscosities.size() > 0;
 
@@ -1035,7 +1040,7 @@ NavierStokesMatrix<dim>::local_pressure_mass_weight(
   const unsigned int &,
   const std::pair<unsigned int, unsigned int> &cell_range) const
 {
-  FEEvaluation<dim, degree_p, degree_p + 1, 1> pressure(data, 1, 1);
+  FEEvaluation<dim, degree_p, degree_p + 1, 1> pressure(data, dof_index_p, quad_index_p);
   for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
     {
       pressure.reinit(cell);
@@ -1060,7 +1065,7 @@ NavierStokesMatrix<dim>::local_pressure_convdiff(
   const std::pair<unsigned int, unsigned int> &     cell_range) const
 {
   typedef VectorizedArray<double>              vector_t;
-  FEEvaluation<dim, degree_p, degree_p + 2, 1> pressure(data, 1);
+  FEEvaluation<dim, degree_p, degree_p + 2, 1> pressure(data, dof_index_p, quad_index_u);
 
   Assert(linearized_velocities.size() > 0, ExcNotImplemented());
 

--- a/source/navier_stokes_matrix.cc
+++ b/source/navier_stokes_matrix.cc
@@ -40,10 +40,10 @@
 template <int dim>
 NavierStokesMatrix<dim>::NavierStokesMatrix(
   const FlowParameters &                                 parameters,
-  const unsigned int                                     dof_index_u,
-  const unsigned int                                     dof_index_p,
-  const unsigned int                                     quad_index_u,
-  const unsigned int                                     quad_index_p,
+  const unsigned int &                                   dof_index_u,
+  const unsigned int &                                   dof_index_p,
+  const unsigned int &                                   quad_index_u,
+  const unsigned int &                                   quad_index_p,
   const LinearAlgebra::distributed::BlockVector<double> &solution_old,
   const LinearAlgebra::distributed::BlockVector<double> &solution_old_old)
   : matrix_free(0)

--- a/tests/simplex_channel.cc
+++ b/tests/simplex_channel.cc
@@ -265,12 +265,13 @@ void
 FlowPastCylinder<dim>::run()
 {
   timer.enter_subsection("Setup grid and initial condition.");
+
+  create_triangulation(triangulation, use_simplex_mesh, n_refinements);
+
   pcout << "Running a " << dim << "D flow past a cylinder "
         << "using " << navier_stokes.time_stepping.name() << ", Q"
         << navier_stokes.get_fe_u().degree << "/Q" << navier_stokes.get_fe_p().degree
         << " elements" << std::endl;
-
-  create_triangulation(triangulation, use_simplex_mesh, n_refinements);
 
   for (unsigned int i = 2; i < 2 * dim; ++i)
     navier_stokes.set_no_slip_boundary(i);


### PR DESCRIPTION
... the information should be propagated throughout the code (in particular `TwoPhaseBaseAlgorithm`) but I leave that to a follow-up PR. For now, we only need it in the `NavierStokes` classes, since we use it as stand-alone solver.