### PR TITLE
1d instance for compute normal added

### DIFF
--- a/source/level_set_okz_compute_normal.cc
+++ b/source/level_set_okz_compute_normal.cc
@@ -270,5 +270,6 @@ LevelSetOKZSolverComputeNormal<dim>::compute_normal(const bool fast_computation)
     }
 }
 
+template class LevelSetOKZSolverComputeNormal<1>;
 template class LevelSetOKZSolverComputeNormal<2>;
 template class LevelSetOKZSolverComputeNormal<3>;


### PR DESCRIPTION
This PR introduces a 1D instance of ```LevelSetOKZComputeNormal```.