### PR TITLE
simplex_bubble parameters: changed global_refinements from 4 to 3

### DIFF
--- a/tests/simplex_bubble.prm
+++ b/tests/simplex_bubble.prm
@@ -40,7 +40,7 @@ subsection Time stepping
 end
 subsection Navier-Stokes
   set dimension            = 2
-  set global refinements   = 4
+  set global refinements   = 3
   set adaptive refinements = 0
   set velocity degree      = 2
   set simplex mesh       = 1


### PR DESCRIPTION
This PR changes the parameter "global_refinements" in the "simplex_bubble.prm" file from 4 to 3, since only meshes with global refinements 1-3 are supported by the simplex_bubble example.