### PR TITLE
Enable NavierStokes<1>

### DIFF
--- a/include/adaflo/sharp_interface.h
+++ b/include/adaflo/sharp_interface.h
@@ -954,6 +954,8 @@ private:
                                                 level_set_solver.get_normal_vector(),
                                                 level_set_solver.get_curvature_vector(),
                                                 navier_stokes_solver.user_rhs.block(0));
+
+    // marching cube algorithm
     else if (!use_auxiliary_surface_mesh && use_sharp_interface)
       compute_force_vector_sharp_interface(QGauss<dim - 1>(2 /*TODO*/),
                                            navier_stokes_solver.mapping,

--- a/include/adaflo/util.h
+++ b/include/adaflo/util.h
@@ -172,13 +172,13 @@ convert_to_tensor(const Tensor<rank_ - 1, dim, VectorizedArrayType> &in)
     {
       Tensor<2, dim, VectorizedArrayType> tens;
 
-    tens[0][0] = in[0];
-    return tens;
-  }
+      tens[0][0] = in[0];
+      return tens;
+    }
   else
-  {
-    Assert(false, ExcNotImplemented());
-  }
+    {
+      Assert(false, ExcNotImplemented());
+    }
 }
 
 /**

--- a/include/adaflo/util.h
+++ b/include/adaflo/util.h
@@ -128,4 +128,68 @@ compute_cell_diameters(const MatrixFree<dim, double> &         matrix_free,
     Utilities::MPI::max(cell_diameter_max, get_communicator(triangulation));
 }
 
+/**
+ * If dim == 1, convert a VectorizedArray<number> to a vector (rank 1 tensor).
+ * This function is useful to obtain equal, vector-valued return types of
+ * FEEvaluation-operations for dim == 1 and dim > 1.
+ */
+template <int dim, typename VectorizedArrayType = VectorizedArray<double>>
+static Tensor<1, dim, VectorizedArrayType>
+convert_to_vector(const VectorizedArrayType &in)
+{
+  AssertThrow(dim == 1, ExcMessage("This operation is not permitted for dim>1."))
+
+    Tensor<1, dim, VectorizedArrayType>
+      vec;
+
+  for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
+    vec[0][v] = in[v];
+
+  return vec;
+}
+
+/**
+ * This function overloads the previous convert_to_vector function, when
+ * the input argument is already given as a rank 1 tensor.
+ */
+template <int dim, typename VectorizedArrayType = VectorizedArray<double>>
+static Tensor<1, dim, VectorizedArrayType>
+convert_to_vector(const Tensor<1, dim, VectorizedArrayType> &in)
+{
+  return in;
+}
+
+/**
+ * If dim == 1, convert a tensor of rank-1 to a tensor of rank. This function
+ * is useful to obtain equal, tensor-rank-valued return types of
+ * FEEvaluation-operations for dim == 1 and dim > 1.
+ */
+template <int rank_, int dim, typename VectorizedArrayType = VectorizedArray<double>>
+static Tensor<rank_, dim, VectorizedArrayType>
+convert_to_tensor(const Tensor<rank_ - 1, dim, VectorizedArrayType> &in)
+{
+  AssertThrow(dim == 1, ExcMessage("This operation is not permitted for dim>1."))
+
+    if (rank_ == 2)
+  {
+    Tensor<2, dim, VectorizedArrayType> tens;
+
+    for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
+      tens[0][0][v] = in[0][v];
+    return tens;
+  }
+  else AssertThrow(false, ExcNotImplemented());
+}
+
+/**
+ * This function overloads the previous convert_to_tensor function, when the input
+ * tensor already has the desired tensor rank.
+ */
+template <int rank_, int dim, typename VectorizedArrayType = VectorizedArray<double>>
+static Tensor<rank_, dim, VectorizedArrayType>
+convert_to_tensor(const Tensor<rank_, dim, VectorizedArrayType> &in)
+{
+  return in;
+}
+
 #endif

--- a/include/adaflo/util.h
+++ b/include/adaflo/util.h
@@ -137,10 +137,9 @@ template <int dim, typename VectorizedArrayType = VectorizedArray<double>>
 static Tensor<1, dim, VectorizedArrayType>
 convert_to_vector(const VectorizedArrayType &in)
 {
-  AssertThrow(dim == 1, ExcMessage("This operation is not permitted for dim>1."))
+  Assert(dim == 1, ExcMessage("This operation is not permitted for dim>1."));
 
-    Tensor<1, dim, VectorizedArrayType>
-      vec;
+  Tensor<1, dim, VectorizedArrayType> vec;
 
   for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
     vec[0][v] = in[v];
@@ -168,17 +167,18 @@ template <int rank_, int dim, typename VectorizedArrayType = VectorizedArray<dou
 static Tensor<rank_, dim, VectorizedArrayType>
 convert_to_tensor(const Tensor<rank_ - 1, dim, VectorizedArrayType> &in)
 {
-  AssertThrow(dim == 1, ExcMessage("This operation is not permitted for dim>1."))
+  Assert(dim == 1, ExcMessage("This operation is not permitted for dim>1."));
 
-    if (rank_ == 2)
-  {
-    Tensor<2, dim, VectorizedArrayType> tens;
+  if (rank_ == 2)
+    {
+      Tensor<2, dim, VectorizedArrayType> tens;
 
-    for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
-      tens[0][0][v] = in[0][v];
-    return tens;
-  }
-  else AssertThrow(false, ExcNotImplemented());
+      for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
+        tens[0][0][v] = in[0][v];
+      return tens;
+    }
+  else
+    AssertThrow(false, ExcNotImplemented());
 }
 
 /**

--- a/source/flow_base_algorithm.cc
+++ b/source/flow_base_algorithm.cc
@@ -277,6 +277,6 @@ FlowBaseAlgorithm<dim>::write_data_output(const std::string &       output_name,
     }
 }
 
-
+template struct FlowBaseAlgorithm<1>;
 template struct FlowBaseAlgorithm<2>;
 template struct FlowBaseAlgorithm<3>;

--- a/source/navier_stokes.cc
+++ b/source/navier_stokes.cc
@@ -277,17 +277,19 @@ NavierStokes<dim>::initialize_data_structures()
                            "other boundary conditions on same boundary!"));
 
 
-  VectorTools::compute_no_normal_flux_constraints(dof_handler_u,
-                                                  0,
-                                                  this->boundary->symmetry,
-                                                  hanging_node_constraints_u,
-                                                  this->mapping);
-  VectorTools::compute_normal_flux_constraints(dof_handler_u,
-                                               0,
-                                               this->boundary->normal_flux,
-                                               hanging_node_constraints_u,
-                                               this->mapping);
-
+  if constexpr (dim > 1)
+    {
+      VectorTools::compute_no_normal_flux_constraints(dof_handler_u,
+                                                      0,
+                                                      this->boundary->symmetry,
+                                                      hanging_node_constraints_u,
+                                                      this->mapping);
+      VectorTools::compute_normal_flux_constraints(dof_handler_u,
+                                                   0,
+                                                   this->boundary->normal_flux,
+                                                   hanging_node_constraints_u,
+                                                   this->mapping);
+    }
   // Now generate the rest of the constraints for the velocity
   constraints_u.merge(hanging_node_constraints_u);
   {
@@ -1491,5 +1493,6 @@ NavierStokes<dim>::print_memory_consumption(std::ostream &stream) const
 
 
 // explicit instantiations
+template class NavierStokes<1>;
 template class NavierStokes<2>;
 template class NavierStokes<3>;

--- a/source/navier_stokes_matrix.cc
+++ b/source/navier_stokes_matrix.cc
@@ -847,7 +847,7 @@ NavierStokesMatrix<dim>::local_operation(
                 grad_u[0][1] = sym;
                 grad_u[1][0] = sym;
                 break;
-              case 1: // TODO??
+              case 1: // nothing todo
                 break;
               default:
                 Assert(false, ExcNotImplemented());

--- a/source/navier_stokes_matrix.cc
+++ b/source/navier_stokes_matrix.cc
@@ -684,8 +684,9 @@ NavierStokesMatrix<dim>::local_operation(
 
       for (unsigned int q = 0; q < velocity.n_q_points; ++q)
         {
-          Tensor<2, dim, vector_t> grad_u     = convert_to_tensor<2,dim,vector_t>(velocity.get_gradient(q));
-          vector_t                 divergence = trace(grad_u);
+          Tensor<2, dim, vector_t> grad_u =
+            convert_to_tensor<2, dim, vector_t>(velocity.get_gradient(q));
+          vector_t divergence = trace(grad_u);
 
           if (parameters.physical_type != FlowParameters::stokes)
             {
@@ -693,7 +694,8 @@ NavierStokesMatrix<dim>::local_operation(
               const vector_t rho = use_variable_coefficients ?
                                      rho_values[q] :
                                      make_vectorized_array<double>(parameters.density);
-              Tensor<1, dim, vector_t> val_u = convert_to_vector<dim, vector_t>(velocity.get_value(q));
+              Tensor<1, dim, vector_t> val_u =
+                convert_to_vector<dim, vector_t>(velocity.get_value(q));
 
               Tensor<1, dim, vector_t> conv = val_u * time_step_weight;
 
@@ -707,8 +709,10 @@ NavierStokesMatrix<dim>::local_operation(
                 {
                   if (parameters.physical_type !=
                       FlowParameters::incompressible_stationary)
-                    conv += convert_to_vector<dim, vector_t>(old.get_value(q)) * time_step_weight_old +
-                            convert_to_vector<dim, vector_t>(old_old.get_value(q)) * time_step_weight_old_old;
+                    conv += convert_to_vector<dim, vector_t>(old.get_value(q)) *
+                              time_step_weight_old +
+                            convert_to_vector<dim, vector_t>(old_old.get_value(q)) *
+                              time_step_weight_old_old;
 
                   // Also store the current velocity and velocity gradient (or
                   // divergence, depending on the linearization scheme). A
@@ -718,15 +722,19 @@ NavierStokesMatrix<dim>::local_operation(
                   // need to extrapolate those velocities.
                   if (need_extrapolated_velocity)
                     {
-                      Tensor<2, dim, vector_t> old_grad     = convert_to_tensor<2,dim,vector_t>(old.get_gradient(q));
-                      Tensor<2, dim, vector_t> old_old_grad = convert_to_tensor<2,dim,vector_t>(old_old.get_gradient(q));
+                      Tensor<2, dim, vector_t> old_grad =
+                        convert_to_tensor<2, dim, vector_t>(old.get_gradient(q));
+                      Tensor<2, dim, vector_t> old_old_grad =
+                        convert_to_tensor<2, dim, vector_t>(old_old.get_gradient(q));
                       for (unsigned int d = 0; d < dim; ++d)
                         for (unsigned int e = 0; e < dim; ++e)
                           old_grad[d][e] = time_stepping->extrapolate(old_grad[d][e],
                                                                       old_old_grad[d][e]);
                       const vector_t           extrapol_divergence = trace(old_grad);
-                      Tensor<1, dim, vector_t> old_val             = convert_to_vector<dim,vector_t>(old.get_value(q));
-                      Tensor<1, dim, vector_t> old_old_val         = convert_to_vector<dim,vector_t>(old_old.get_value(q));
+                      Tensor<1, dim, vector_t> old_val =
+                        convert_to_vector<dim, vector_t>(old.get_value(q));
+                      Tensor<1, dim, vector_t> old_old_val =
+                        convert_to_vector<dim, vector_t>(old_old.get_value(q));
                       for (unsigned int d = 0; d < dim; ++d)
                         old_val[d] =
                           time_stepping->extrapolate(old_val[d], old_old_val[d]);
@@ -839,6 +847,8 @@ NavierStokesMatrix<dim>::local_operation(
                 grad_u[0][1] = sym;
                 grad_u[1][0] = sym;
                 break;
+              case 1: // TODO??
+                break;
               default:
                 Assert(false, ExcNotImplemented());
 #pragma GCC diagnostic push
@@ -853,7 +863,7 @@ NavierStokesMatrix<dim>::local_operation(
                 grad_u[d][d] -= pres;
             }
 
-          if constexpr (dim==1)
+          if constexpr (dim == 1)
             velocity.submit_gradient(grad_u[0], q);
           else
             velocity.submit_gradient(grad_u, q);
@@ -915,7 +925,7 @@ NavierStokesMatrix<dim>::local_divergence(
                  -mu_values[q]) :
               make_vectorized_array(-1.);
 
-          if constexpr (dim==1)
+          if constexpr (dim == 1)
             pressure.submit_value(weight * velocity.get_gradient(q), q);
           else
             pressure.submit_value(weight * velocity.get_divergence(q), q);

--- a/source/navier_stokes_matrix.cc
+++ b/source/navier_stokes_matrix.cc
@@ -863,10 +863,7 @@ NavierStokesMatrix<dim>::local_operation(
                 grad_u[d][d] -= pres;
             }
 
-          if constexpr (dim == 1)
-            velocity.submit_gradient(grad_u[0], q);
-          else
-            velocity.submit_gradient(grad_u, q);
+          velocity.submit_gradient(grad_u, q);
         }
 
       // finally, integrate velocity and pressure and increase pointers to
@@ -925,10 +922,7 @@ NavierStokesMatrix<dim>::local_divergence(
                  -mu_values[q]) :
               make_vectorized_array(-1.);
 
-          if constexpr (dim == 1)
-            pressure.submit_value(weight * velocity.get_gradient(q), q);
-          else
-            pressure.submit_value(weight * velocity.get_divergence(q), q);
+          pressure.submit_value(weight * velocity.get_divergence(q), q);
         }
 
       pressure.integrate(true, false);

--- a/source/navier_stokes_matrix.cc
+++ b/source/navier_stokes_matrix.cc
@@ -20,6 +20,7 @@
 #include <deal.II/matrix_free/fe_evaluation.h>
 
 #include <adaflo/navier_stokes_matrix.h>
+#include <adaflo/util.h>
 
 
 // TODO:
@@ -683,7 +684,7 @@ NavierStokesMatrix<dim>::local_operation(
 
       for (unsigned int q = 0; q < velocity.n_q_points; ++q)
         {
-          Tensor<2, dim, vector_t> grad_u     = velocity.get_gradient(q);
+          Tensor<2, dim, vector_t> grad_u     = convert_to_tensor<2,dim,vector_t>(velocity.get_gradient(q));
           vector_t                 divergence = trace(grad_u);
 
           if (parameters.physical_type != FlowParameters::stokes)
@@ -692,7 +693,7 @@ NavierStokesMatrix<dim>::local_operation(
               const vector_t rho = use_variable_coefficients ?
                                      rho_values[q] :
                                      make_vectorized_array<double>(parameters.density);
-              Tensor<1, dim, vector_t> val_u = velocity.get_value(q);
+              Tensor<1, dim, vector_t> val_u = convert_to_vector<dim, vector_t>(velocity.get_value(q));
 
               Tensor<1, dim, vector_t> conv = val_u * time_step_weight;
 
@@ -706,8 +707,8 @@ NavierStokesMatrix<dim>::local_operation(
                 {
                   if (parameters.physical_type !=
                       FlowParameters::incompressible_stationary)
-                    conv += old.get_value(q) * time_step_weight_old +
-                            old_old.get_value(q) * time_step_weight_old_old;
+                    conv += convert_to_vector<dim, vector_t>(old.get_value(q)) * time_step_weight_old +
+                            convert_to_vector<dim, vector_t>(old_old.get_value(q)) * time_step_weight_old_old;
 
                   // Also store the current velocity and velocity gradient (or
                   // divergence, depending on the linearization scheme). A
@@ -717,15 +718,15 @@ NavierStokesMatrix<dim>::local_operation(
                   // need to extrapolate those velocities.
                   if (need_extrapolated_velocity)
                     {
-                      Tensor<2, dim, vector_t> old_grad     = old.get_gradient(q);
-                      Tensor<2, dim, vector_t> old_old_grad = old_old.get_gradient(q);
+                      Tensor<2, dim, vector_t> old_grad     = convert_to_tensor<2,dim,vector_t>(old.get_gradient(q));
+                      Tensor<2, dim, vector_t> old_old_grad = convert_to_tensor<2,dim,vector_t>(old_old.get_gradient(q));
                       for (unsigned int d = 0; d < dim; ++d)
                         for (unsigned int e = 0; e < dim; ++e)
                           old_grad[d][e] = time_stepping->extrapolate(old_grad[d][e],
                                                                       old_old_grad[d][e]);
                       const vector_t           extrapol_divergence = trace(old_grad);
-                      Tensor<1, dim, vector_t> old_val             = old.get_value(q);
-                      Tensor<1, dim, vector_t> old_old_val         = old_old.get_value(q);
+                      Tensor<1, dim, vector_t> old_val             = convert_to_vector<dim,vector_t>(old.get_value(q));
+                      Tensor<1, dim, vector_t> old_old_val         = convert_to_vector<dim,vector_t>(old_old.get_value(q));
                       for (unsigned int d = 0; d < dim; ++d)
                         old_val[d] =
                           time_stepping->extrapolate(old_val[d], old_old_val[d]);
@@ -852,7 +853,10 @@ NavierStokesMatrix<dim>::local_operation(
                 grad_u[d][d] -= pres;
             }
 
-          velocity.submit_gradient(grad_u, q);
+          if constexpr (dim==1)
+            velocity.submit_gradient(grad_u[0], q);
+          else
+            velocity.submit_gradient(grad_u, q);
         }
 
       // finally, integrate velocity and pressure and increase pointers to
@@ -911,7 +915,10 @@ NavierStokesMatrix<dim>::local_divergence(
                  -mu_values[q]) :
               make_vectorized_array(-1.);
 
-          pressure.submit_value(weight * velocity.get_divergence(q), q);
+          if constexpr (dim==1)
+            pressure.submit_value(weight * velocity.get_gradient(q), q);
+          else
+            pressure.submit_value(weight * velocity.get_divergence(q), q);
         }
 
       pressure.integrate(true, false);
@@ -1161,5 +1168,6 @@ NavierStokesMatrix<dim>::get_matvec_statistics() const
 
 
 // explicit instantiations
+template class NavierStokesMatrix<1>;
 template class NavierStokesMatrix<2>;
 template class NavierStokesMatrix<3>;

--- a/source/navier_stokes_preconditioner.cc
+++ b/source/navier_stokes_preconditioner.cc
@@ -2554,6 +2554,7 @@ NavierStokesPreconditioner<dim>::IntegrationHelper::get_indices_sub_elements(
         {
           auto lexicographic = fe_q->get_poly_space_numbering_inverse();
           dof_to_lin.resize(degree, std::vector<unsigned int>(n_dofs));
+
           // elx (degree=2)
           //      (0)        (1)
           // (*) ------ (*) ----- (*)

--- a/source/navier_stokes_preconditioner.cc
+++ b/source/navier_stokes_preconditioner.cc
@@ -2644,5 +2644,6 @@ NavierStokesPreconditioner<dim>::get_timer_statistics() const
 
 
 // explicit instantiations
+template class NavierStokesPreconditioner<1>;
 template class NavierStokesPreconditioner<2>;
 template class NavierStokesPreconditioner<3>;

--- a/tests/1d_flow.cc
+++ b/tests/1d_flow.cc
@@ -1,0 +1,263 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (C) 2014 - 2016 by the adaflo authors
+//
+// This file is part of the adaflo library.
+//
+// The adaflo library is free software; you can use it, redistribute it,
+// and/or modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2.1 of the
+// License, or (at your option) any later version.  The full text of the
+// license can be found in the file LICENSE at the top level of the adaflo
+// distribution.
+//
+// --------------------------------------------------------------------------
+
+#include <deal.II/base/function.h>
+#include <deal.II/base/function_time.h>
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/grid_refinement.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_in.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/manifold_lib.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/vector_tools.h>
+
+#include <adaflo/navier_stokes.h>
+#include <adaflo/time_stepping.h>
+
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+
+using namespace dealii;
+
+template <int dim>
+class InflowVelocity : public Function<dim>
+{
+public:
+  InflowVelocity(const double time)
+    : Function<dim>()
+  {}
+
+  double
+  value(const Point<dim> &p, const unsigned int component = 0) const override
+  {
+    const double time = this->get_time();
+    if constexpr (dim == 1)
+      return (2 - p[0] / 2.5);
+    // return (2-p[0]/2.5)*(1+time);
+    else
+      AssertThrow(false, ExcMessage("Advection field for dim!=1 not implemented"));
+  }
+};
+
+
+template <int dim>
+class ChannelFlow
+{
+public:
+  ChannelFlow(const FlowParameters &parameters);
+  void
+  run();
+
+private:
+  void
+  compute_statistics() const;
+  void
+  output_results() const;
+
+  ConditionalOStream pcout;
+
+  mutable TimerOutput timer;
+
+  Triangulation<dim> triangulation;
+  NavierStokes<dim>  navier_stokes;
+};
+
+template <int dim>
+ChannelFlow<dim>::ChannelFlow(const FlowParameters &parameters)
+  : pcout(std::cout, (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0))
+  , timer(pcout, TimerOutput::summary, TimerOutput::cpu_and_wall_times)
+  , navier_stokes(parameters, triangulation, &timer)
+{}
+
+
+
+template <int dim>
+void
+ChannelFlow<dim>::compute_statistics() const
+{
+  timer.enter_subsection("Compute statistics.");
+
+  timer.leave_subsection();
+}
+
+
+
+template <int dim>
+void
+ChannelFlow<dim>::output_results() const
+{
+  timer.enter_subsection("Generate output.");
+
+  navier_stokes.output_solution(navier_stokes.get_parameters().output_filename);
+
+  timer.leave_subsection();
+}
+
+
+template <int dim>
+void
+create_triangulation(Triangulation<dim> &tria)
+{
+  if (dim == 1)
+    {
+      GridGenerator::hyper_rectangle(tria, Point<dim>(0.0), Point<dim>(2.5));
+      tria.refine_global(10);
+
+      for (auto &cell : tria.cell_iterators())
+        for (auto &face : cell->face_iterators())
+          if ((face->at_boundary()))
+            {
+              if (face->center()[0] == 0)
+                face->set_boundary_id(0);
+              else if (face->center()[0] == 2.5)
+                face->set_boundary_id(1);
+            }
+    }
+  else
+    AssertThrow(false, ExcNotImplemented());
+}
+
+
+
+template <int dim>
+void
+ChannelFlow<dim>::run()
+{
+  timer.enter_subsection("Setup grid and initial condition.");
+  pcout << "Running a " << dim << "D flow past a cylinder "
+        << "using " << navier_stokes.time_stepping.name() << ", Q"
+        << navier_stokes.get_fe_u().degree << "/Q" << navier_stokes.get_fe_p().degree
+        << " elements" << std::endl;
+
+  create_triangulation(triangulation);
+
+  // set boundary conditions
+  navier_stokes.set_velocity_dirichlet_boundary(
+    0, std::make_shared<InflowVelocity<dim>>(2.));
+  // navier_stokes.set_open_boundary(1, std::make_shared<Functions::ZeroFunction<dim>>());
+  navier_stokes.set_velocity_dirichlet_boundary(
+    1, std::make_shared<InflowVelocity<dim>>(1.));
+  // navier_stokes.set_no_slip_boundary(1);
+  navier_stokes.fix_pressure_constant(
+    0, std::make_shared<Functions::ConstantFunction<dim>>(2));
+  // navier_stokes.set_open_boundary_with_normal_flux(1,
+  // std::make_shared<Functions::ZeroFunction<dim>>());
+  // navier_stokes.set_open_boundary_with_normal_flux(0,
+  // std::make_shared<Functions::ConstantFunction<dim>>(2));
+
+  timer.leave_subsection();
+
+  navier_stokes.setup_problem(InflowVelocity<dim>(0.));
+  navier_stokes.print_n_dofs();
+
+  output_results();
+
+  while (navier_stokes.time_stepping.at_end() == false)
+    {
+      navier_stokes.advance_time_step();
+      compute_statistics();
+      if (navier_stokes.time_stepping.at_tick(
+            navier_stokes.get_parameters().output_frequency))
+        output_results();
+    }
+
+  if (!navier_stokes.time_stepping.at_tick(
+        navier_stokes.get_parameters().output_frequency))
+    output_results();
+}
+
+
+
+/* ----------------------------------------------------------------------- */
+
+
+
+/* ----------------------------------------------------------------------- */
+
+int
+main(int argc, char **argv)
+{
+  try
+    {
+      using namespace dealii;
+
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc,
+                                                          argv,
+                                                          numbers::invalid_unsigned_int);
+      // AssertDimension(Utilities::MPI::n_mpi_processes(this->mpi_communicator), 1);
+      deallog.depth_console(0);
+
+      std::string paramfile;
+      if (argc > 1)
+        paramfile = argv[1];
+      else
+        paramfile = "1d_flow.prm";
+
+      FlowParameters parameters(paramfile);
+      if (parameters.dimension == 1)
+        {
+          ChannelFlow<1> channel(parameters);
+          channel.run();
+        }
+      else
+        {
+          AssertThrow(false, ExcMessage("Invalid dimension"));
+        }
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------" << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------" << std::endl;
+
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------" << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------" << std::endl;
+      return 1;
+    }
+
+  return 0;
+}

--- a/tests/1d_flow.cc
+++ b/tests/1d_flow.cc
@@ -61,27 +61,6 @@ using namespace dealii;
 
 
 template <int dim>
-class InflowVelocity : public Function<dim>
-{
-public:
-  InflowVelocity()
-    : Function<dim>()
-  {}
-
-  double
-  value(const Point<dim> &p, const unsigned int component = 0) const override
-  {
-    (void)p;
-    (void)component;
-    if constexpr (dim == 1)
-      return 2.0;
-    else
-      AssertThrow(false, ExcMessage("Advection field for dim!=1 not implemented"));
-  }
-};
-
-
-template <int dim>
 class ChannelFlow
 {
 public:
@@ -130,11 +109,11 @@ create_triangulation(Triangulation<dim> &tria)
 
   for (auto &cell : tria.cell_iterators())
     for (auto &face : cell->face_iterators())
-      if ((face->at_boundary()))
+      if (face->at_boundary())
         {
-          if (face->center()[0] == 0)
+          if (std::abs(face->center()[0]) < 1e-12)
             face->set_boundary_id(0);
-          else if (face->center()[0] == 2.5)
+          else if (std::abs(face->center()[0] - 2.5) < 1e-12)
             face->set_boundary_id(1);
         }
 }
@@ -160,7 +139,7 @@ ChannelFlow<dim>::run()
 
   timer.leave_subsection();
 
-  navier_stokes.setup_problem(InflowVelocity<dim>());
+  navier_stokes.setup_problem(Functions::ConstantFunction<dim>(2));
   navier_stokes.print_n_dofs();
 
   output_results();

--- a/tests/1d_flow.output
+++ b/tests/1d_flow.output
@@ -1,0 +1,952 @@
+Running a 1D flow using BDF-2, Q2/Q1 elements
+ Number of active cells: 2048.
+ Number of degrees of freedom (velocity/pressure): 6146 (4097 + 2049).
+ Approximate size last cell: 0.0012207
+
+Time step #1, advancing from t_n-1 = 0 to t = 0.01 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   2.236e+00        ILUs       6.91e+01       28       6.94e-06
+   6.940e-06        ---        7.16e-04       24       4.61e-10
+   4.602e-10     converged.
+
+-- Statistics --                    min      avg      max avg/call  p_min  p_max
+-- Statistics -- memory [MB] :      298      298      298           0      0     
+-- Statistics -- nln solver  :     1.51     1.51     1.51     1.51  0      0     
+-- Statistics --  lin solver :      1.2      1.2      1.2      0.6  0      0     
+-- Statistics --   mat-vec   :    0.606    0.606    0.606   0.0108  0      0     
+-- Statistics --   full prec :    0.532    0.532    0.532   0.0095  0      0     
+-- Statistics --   velocity  :   0.0327   0.0327   0.0327 0.000585  0      0     
+-- Statistics --   div matrix:    0.473    0.473    0.473  0.00845  0      0     
+-- Statistics --   pres mass :  0.00166  0.00166  0.00166 2.96e-05  0      0     
+-- Statistics --   pres Poiss:   0.0231   0.0231   0.0231 0.000413  0      0     
+
+
+Time step #2, advancing from t_n-1 = 0.01 to t = 0.02 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   2.470e-02        ILUs       2.56e-01        0       1.02e-09
+   1.023e-09        ---        1.61e-08        0       3.78e-10
+   3.781e-10     converged.
+
+
+Time step #3, advancing from t_n-1 = 0.02 to t = 0.03 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.297e-09        ---        4.17e-08        0       4.15e-10
+   4.149e-10     converged.
+
+
+Time step #4, advancing from t_n-1 = 0.03 to t = 0.04 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   8.118e-10        ---        1.36e-07        2       3.16e-10
+   3.165e-10     converged.
+
+
+Time step #5, advancing from t_n-1 = 0.04 to t = 0.05 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.655e-09        ILUs       1.24e-07        1       4.69e-10
+   4.687e-10     converged.
+
+
+Time step #6, advancing from t_n-1 = 0.05 to t = 0.06 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.195e-09        ---        1.03e-07        2       2.65e-10
+   2.653e-10     converged.
+
+
+Time step #7, advancing from t_n-1 = 0.06 to t = 0.07 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.570e-09        ILUs       1.52e-07        2       2.54e-10
+   2.542e-10     converged.
+
+
+Time step #8, advancing from t_n-1 = 0.07 to t = 0.08 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.192e-09        ---        9.01e-08        1       3.49e-10
+   3.491e-10     converged.
+
+
+Time step #9, advancing from t_n-1 = 0.08 to t = 0.09 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.271e-09        ILUs       7.29e-08        2       3.15e-10
+   3.151e-10     converged.
+
+
+Time step #10, advancing from t_n-1 = 0.09 to t = 0.1 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.233e-09        ---        6.10e-08        2       2.75e-10
+   2.750e-10     converged.
+
+
+Time step #11, advancing from t_n-1 = 0.1 to t = 0.11 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.130e-09        ILUs       4.42e-08        1       4.52e-10
+   4.524e-10     converged.
+
+-- Statistics --                    min      avg      max avg/call  p_min  p_max
+-- Statistics -- memory [MB] :      305      305      305           0      0     
+-- Statistics -- nln solver  :     2.33     2.33     2.33    0.233  0      0     
+-- Statistics --  lin solver :    0.785    0.785    0.785   0.0714  0      0     
+-- Statistics --   mat-vec   :    0.425    0.425    0.425   0.0122  0      0     
+-- Statistics --   full prec :    0.337    0.337    0.337  0.00962  0      0     
+-- Statistics --   velocity  :   0.0388   0.0388   0.0388  0.00111  0      0     
+-- Statistics --   div matrix:    0.273    0.273    0.273  0.00781  0      0     
+-- Statistics --   pres mass :  0.00107  0.00107  0.00107 3.04e-05  0      0     
+-- Statistics --   pres Poiss:   0.0226   0.0226   0.0226 0.000646  0      0     
+
+
+Time step #12, advancing from t_n-1 = 0.11 to t = 0.12 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.258e-09        ---        5.24e-08        2       3.50e-10
+   3.498e-10     converged.
+
+
+Time step #13, advancing from t_n-1 = 0.12 to t = 0.13 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.342e-09        ILUs       5.28e-08        2       3.20e-10
+   3.199e-10     converged.
+
+
+Time step #14, advancing from t_n-1 = 0.13 to t = 0.14 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.188e-09        ---        4.87e-08        1       5.00e-10
+   4.995e-10     converged.
+
+
+Time step #15, advancing from t_n-1 = 0.14 to t = 0.15 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.396e-09        ILUs       5.18e-08        2       4.08e-10
+   4.077e-10     converged.
+
+
+Time step #16, advancing from t_n-1 = 0.15 to t = 0.16 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.462e-09        ---        5.67e-08        2       3.74e-10
+   3.744e-10     converged.
+
+
+Time step #17, advancing from t_n-1 = 0.16 to t = 0.17 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.340e-09        ILUs       5.43e-08        2       3.92e-10
+   3.916e-10     converged.
+
+
+Time step #18, advancing from t_n-1 = 0.17 to t = 0.18 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.433e-09        ---        5.30e-08        2       3.89e-10
+   3.889e-10     converged.
+
+
+Time step #19, advancing from t_n-1 = 0.18 to t = 0.19 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.400e-09        ILUs       5.24e-08        2       4.03e-10
+   4.034e-10     converged.
+
+
+Time step #20, advancing from t_n-1 = 0.19 to t = 0.2 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.393e-09        ---        5.19e-08        2       4.04e-10
+   4.042e-10     converged.
+
+
+Time step #21, advancing from t_n-1 = 0.2 to t = 0.21 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.440e-09        ILUs       5.24e-08        2       4.18e-10
+   4.178e-10     converged.
+
+-- Statistics --                    min      avg      max avg/call  p_min  p_max
+-- Statistics -- memory [MB] :      307      307      307           0      0     
+-- Statistics -- nln solver  :     2.09     2.09     2.09    0.209  0      0     
+-- Statistics --  lin solver :    0.568    0.568    0.568   0.0568  0      0     
+-- Statistics --   mat-vec   :    0.215    0.215    0.215  0.00551  0      0     
+-- Statistics --   full prec :     0.31     0.31     0.31  0.00794  0      0     
+-- Statistics --   velocity  :    0.052    0.052    0.052  0.00133  0      0     
+-- Statistics --   div matrix:    0.212    0.212    0.212  0.00543  0      0     
+-- Statistics --   pres mass :  0.00258  0.00258  0.00258 6.62e-05  0      0     
+-- Statistics --   pres Poiss:   0.0423   0.0423   0.0423  0.00108  0      0     
+
+
+Time step #22, advancing from t_n-1 = 0.21 to t = 0.22 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.428e-09        ---        5.27e-08        2       4.24e-10
+   4.240e-10     converged.
+
+
+Time step #23, advancing from t_n-1 = 0.22 to t = 0.23 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.467e-09        ILUs       5.32e-08        2       4.35e-10
+   4.350e-10     converged.
+
+
+Time step #24, advancing from t_n-1 = 0.23 to t = 0.24 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.481e-09        ---        5.37e-08        2       4.46e-10
+   4.458e-10     converged.
+
+
+Time step #25, advancing from t_n-1 = 0.24 to t = 0.25 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.508e-09        ILUs       5.44e-08        2       4.56e-10
+   4.558e-10     converged.
+
+
+Time step #26, advancing from t_n-1 = 0.25 to t = 0.26 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.534e-09        ---        5.52e-08        2       4.68e-10
+   4.682e-10     converged.
+
+
+Time step #27, advancing from t_n-1 = 0.26 to t = 0.27 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.563e-09        ILUs       5.60e-08        2       4.80e-10
+   4.805e-10     converged.
+
+
+Time step #28, advancing from t_n-1 = 0.27 to t = 0.28 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.593e-09        ---        5.70e-08        2       4.93e-10
+   4.926e-10     converged.
+
+
+Time step #29, advancing from t_n-1 = 0.28 to t = 0.29 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.628e-09        ILUs       7.86e-08        3       2.24e-10
+   2.244e-10     converged.
+
+
+Time step #30, advancing from t_n-1 = 0.29 to t = 0.3 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   2.290e-09        ---        5.93e-08        2       4.36e-10
+   4.362e-10     converged.
+
+
+Time step #31, advancing from t_n-1 = 0.3 to t = 0.31 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.262e-09        ILUs       4.15e-08        2       3.35e-10
+   3.355e-10     converged.
+
+-- Statistics --                    min      avg      max avg/call  p_min  p_max
+-- Statistics -- memory [MB] :      309      309      309           0      0     
+-- Statistics -- nln solver  :     2.06     2.06     2.06    0.206  0      0     
+-- Statistics --  lin solver :    0.529    0.529    0.529   0.0529  0      0     
+-- Statistics --   mat-vec   :    0.202    0.202    0.202  0.00493  0      0     
+-- Statistics --   full prec :    0.272    0.272    0.272  0.00664  0      0     
+-- Statistics --   velocity  :    0.051    0.051    0.051  0.00124  0      0     
+-- Statistics --   div matrix:    0.184    0.184    0.184  0.00448  0      0     
+-- Statistics --   pres mass :  0.00147  0.00147  0.00147 3.58e-05  0      0     
+-- Statistics --   pres Poiss:    0.035    0.035    0.035 0.000853  0      0     
+
+
+Time step #32, advancing from t_n-1 = 0.31 to t = 0.32 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.430e-09        ---        4.17e-08        2       3.74e-10
+   3.745e-10     converged.
+
+
+Time step #33, advancing from t_n-1 = 0.32 to t = 0.33 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.076e-09        ILUs       4.06e-08        2       4.02e-10
+   4.023e-10     converged.
+
+
+Time step #34, advancing from t_n-1 = 0.33 to t = 0.34 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.256e-09        ---        4.17e-08        2       3.74e-10
+   3.736e-10     converged.
+
+
+Time step #35, advancing from t_n-1 = 0.34 to t = 0.35 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.246e-09        ILUs       4.32e-08        2       4.27e-10
+   4.273e-10     converged.
+
+
+Time step #36, advancing from t_n-1 = 0.35 to t = 0.36 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.248e-09        ---        4.37e-08        2       4.13e-10
+   4.126e-10     converged.
+
+
+Time step #37, advancing from t_n-1 = 0.36 to t = 0.37 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.336e-09        ILUs       4.51e-08        2       4.37e-10
+   4.367e-10     converged.
+
+
+Time step #38, advancing from t_n-1 = 0.37 to t = 0.38 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.320e-09        ---        4.63e-08        2       4.52e-10
+   4.516e-10     converged.
+
+
+Time step #39, advancing from t_n-1 = 0.38 to t = 0.39 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.388e-09        ILUs       4.74e-08        2       4.60e-10
+   4.595e-10     converged.
+
+
+Time step #40, advancing from t_n-1 = 0.39 to t = 0.4 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.418e-09        ---        4.87e-08        2       4.82e-10
+   4.824e-10     converged.
+
+
+Time step #41, advancing from t_n-1 = 0.4 to t = 0.41 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.458e-09        ILUs       5.01e-08        2       4.94e-10
+   4.941e-10     converged.
+
+-- Statistics --                    min      avg      max avg/call  p_min  p_max
+-- Statistics -- memory [MB] :      310      310      310           0      0     
+-- Statistics -- nln solver  :     2.39     2.39     2.39    0.239  0      0     
+-- Statistics --  lin solver :     0.81     0.81     0.81    0.081  0      0     
+-- Statistics --   mat-vec   :    0.376    0.376    0.376   0.0094  0      0     
+-- Statistics --   full prec :    0.386    0.386    0.386  0.00964  0      0     
+-- Statistics --   velocity  :   0.0266   0.0266   0.0266 0.000664  0      0     
+-- Statistics --   div matrix:     0.31     0.31     0.31  0.00776  0      0     
+-- Statistics --   pres mass :   0.0012   0.0012   0.0012    3e-05  0      0     
+-- Statistics --   pres Poiss:   0.0467   0.0467   0.0467  0.00117  0      0     
+
+
+Time step #42, advancing from t_n-1 = 0.41 to t = 0.42 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.509e-09        ---        7.28e-08        3       1.94e-10
+   1.945e-10     converged.
+
+
+Time step #43, advancing from t_n-1 = 0.42 to t = 0.43 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   2.212e-09        ILUs       5.43e-08        2       4.66e-10
+   4.659e-10     converged.
+
+
+Time step #44, advancing from t_n-1 = 0.43 to t = 0.44 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.255e-09        ---        3.99e-08        2       3.87e-10
+   3.867e-10     converged.
+
+
+Time step #45, advancing from t_n-1 = 0.44 to t = 0.45 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.431e-09        ILUs       4.00e-08        2       3.96e-10
+   3.956e-10     converged.
+
+
+Time step #46, advancing from t_n-1 = 0.45 to t = 0.46 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.106e-09        ---        4.02e-08        2       4.45e-10
+   4.451e-10     converged.
+
+
+Time step #47, advancing from t_n-1 = 0.46 to t = 0.47 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.261e-09        ILUs       4.13e-08        2       4.14e-10
+   4.140e-10     converged.
+
+
+Time step #48, advancing from t_n-1 = 0.47 to t = 0.48 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.305e-09        ---        4.31e-08        2       4.67e-10
+   4.669e-10     converged.
+
+
+Time step #49, advancing from t_n-1 = 0.48 to t = 0.49 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.296e-09        ILUs       4.42e-08        2       4.67e-10
+   4.669e-10     converged.
+
+
+Time step #50, advancing from t_n-1 = 0.49 to t = 0.5 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.391e-09        ---        4.59e-08        2       4.84e-10
+   4.842e-10     converged.
+
+
+Time step #51, advancing from t_n-1 = 0.5 to t = 0.51 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.407e-09        ILUs       6.71e-08        3       2.11e-10
+   2.111e-10     converged.
+
+-- Statistics --                    min      avg      max avg/call  p_min  p_max
+-- Statistics -- memory [MB] :      311      311      311           0      0     
+-- Statistics -- nln solver  :     1.93     1.93     1.93    0.193  0      0     
+-- Statistics --  lin solver :    0.491    0.491    0.491   0.0491  0      0     
+-- Statistics --   mat-vec   :    0.246    0.246    0.246  0.00587  0      0     
+-- Statistics --   full prec :    0.218    0.218    0.218  0.00518  0      0     
+-- Statistics --   velocity  :   0.0397   0.0397   0.0397 0.000946  0      0     
+-- Statistics --   div matrix:    0.144    0.144    0.144  0.00342  0      0     
+-- Statistics --   pres mass :  0.00192  0.00192  0.00192 4.57e-05  0      0     
+-- Statistics --   pres Poiss:   0.0264   0.0264   0.0264 0.000629  0      0     
+
+
+Time step #52, advancing from t_n-1 = 0.51 to t = 0.52 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   2.078e-09        ---        4.77e-08        2       4.79e-10
+   4.794e-10     converged.
+
+
+Time step #53, advancing from t_n-1 = 0.52 to t = 0.53 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.174e-09        ILUs       4.04e-08        2       4.69e-10
+   4.693e-10     converged.
+
+
+Time step #54, advancing from t_n-1 = 0.53 to t = 0.54 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.442e-09        ---        3.91e-08        2       4.07e-10
+   4.069e-10     converged.
+
+
+Time step #55, advancing from t_n-1 = 0.54 to t = 0.55 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.226e-09        ILUs       5.14e-08        3       2.99e-10
+   2.994e-10     converged.
+
+
+Time step #56, advancing from t_n-1 = 0.55 to t = 0.56 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.581e-09        ---        3.85e-08        2       3.85e-10
+   3.853e-10     converged.
+
+
+Time step #57, advancing from t_n-1 = 0.56 to t = 0.57 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.112e-09        ILUs       3.72e-08        2       4.31e-10
+   4.308e-10     converged.
+
+
+Time step #58, advancing from t_n-1 = 0.57 to t = 0.58 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.212e-09        ---        3.63e-08        2       3.99e-10
+   3.995e-10     converged.
+
+
+Time step #59, advancing from t_n-1 = 0.58 to t = 0.59 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.230e-09        ILUs       3.73e-08        2       4.56e-10
+   4.563e-10     converged.
+
+
+Time step #60, advancing from t_n-1 = 0.59 to t = 0.6 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.206e-09        ---        3.93e-08        2       4.58e-10
+   4.582e-10     converged.
+
+
+Time step #61, advancing from t_n-1 = 0.6 to t = 0.61 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.299e-09        ILUs       4.12e-08        2       4.67e-10
+   4.668e-10     converged.
+
+-- Statistics --                    min      avg      max avg/call  p_min  p_max
+-- Statistics -- memory [MB] :      312      312      312           0      0     
+-- Statistics -- nln solver  :     2.37     2.37     2.37    0.237  0      0     
+-- Statistics --  lin solver :    0.822    0.822    0.822   0.0822  0      0     
+-- Statistics --   mat-vec   :    0.392    0.392    0.392  0.00957  0      0     
+-- Statistics --   full prec :    0.392    0.392    0.392  0.00956  0      0     
+-- Statistics --   velocity  :   0.0379   0.0379   0.0379 0.000925  0      0     
+-- Statistics --   div matrix:    0.322    0.322    0.322  0.00785  0      0     
+-- Statistics --   pres mass :  0.00116  0.00116  0.00116 2.84e-05  0      0     
+-- Statistics --   pres Poiss:     0.03     0.03     0.03 0.000732  0      0     
+
+
+Time step #62, advancing from t_n-1 = 0.61 to t = 0.62 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.307e-09        ---        4.30e-08        2       4.99e-10
+   4.990e-10     converged.
+
+
+Time step #63, advancing from t_n-1 = 0.62 to t = 0.63 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.372e-09        ILUs       5.80e-08        3       2.88e-10
+   2.884e-10     converged.
+
+
+Time step #64, advancing from t_n-1 = 0.63 to t = 0.64 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.775e-09        ---        4.30e-08        2       4.62e-10
+   4.622e-10     converged.
+
+
+Time step #65, advancing from t_n-1 = 0.64 to t = 0.65 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.205e-09        ILUs       4.17e-08        2       4.87e-10
+   4.873e-10     converged.
+
+
+Time step #66, advancing from t_n-1 = 0.65 to t = 0.66 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.422e-09        ---        4.08e-08        2       4.50e-10
+   4.496e-10     converged.
+
+
+Time step #67, advancing from t_n-1 = 0.66 to t = 0.67 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.350e-09        ILUs       5.06e-08        3       3.42e-10
+   3.418e-10     converged.
+
+
+Time step #68, advancing from t_n-1 = 0.67 to t = 0.68 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.522e-09        ---        4.04e-08        2       4.30e-10
+   4.298e-10     converged.
+
+
+Time step #69, advancing from t_n-1 = 0.68 to t = 0.69 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.260e-09        ILUs       4.01e-08        2       4.89e-10
+   4.895e-10     converged.
+
+
+Time step #70, advancing from t_n-1 = 0.69 to t = 0.7 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.311e-09        ---        3.98e-08        2       4.66e-10
+   4.660e-10     converged.
+
+
+Time step #71, advancing from t_n-1 = 0.7 to t = 0.71 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.352e-09        ILUs       5.13e-08        3       3.25e-10
+   3.251e-10     converged.
+
+-- Statistics --                    min      avg      max avg/call  p_min  p_max
+-- Statistics -- memory [MB] :      312      312      312           0      0     
+-- Statistics -- nln solver  :     2.27     2.27     2.27    0.227  0      0     
+-- Statistics --  lin solver :    0.771    0.771    0.771   0.0771  0      0     
+-- Statistics --   mat-vec   :    0.298    0.298    0.298  0.00694  0      0     
+-- Statistics --   full prec :    0.438    0.438    0.438   0.0102  0      0     
+-- Statistics --   velocity  :   0.0459   0.0459   0.0459  0.00107  0      0     
+-- Statistics --   div matrix:    0.341    0.341    0.341  0.00792  0      0     
+-- Statistics --   pres mass :   0.0155   0.0155   0.0155  0.00036  0      0     
+-- Statistics --   pres Poiss:   0.0298   0.0298   0.0298 0.000692  0      0     
+
+
+Time step #72, advancing from t_n-1 = 0.71 to t = 0.72 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.536e-09        ---        4.07e-08        2       4.43e-10
+   4.430e-10     converged.
+
+
+Time step #73, advancing from t_n-1 = 0.72 to t = 0.73 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.239e-09        ILUs       4.06e-08        2       4.87e-10
+   4.870e-10     converged.
+
+
+Time step #74, advancing from t_n-1 = 0.73 to t = 0.74 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.348e-09        ---        4.00e-08        2       4.74e-10
+   4.738e-10     converged.
+
+
+Time step #75, advancing from t_n-1 = 0.74 to t = 0.75 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.363e-09        ILUs       5.04e-08        3       3.39e-10
+   3.395e-10     converged.
+
+
+Time step #76, advancing from t_n-1 = 0.75 to t = 0.76 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.520e-09        ---        4.07e-08        2       4.50e-10
+   4.504e-10     converged.
+
+
+Time step #77, advancing from t_n-1 = 0.76 to t = 0.77 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.269e-09        ILUs       4.12e-08        2       4.99e-10
+   4.986e-10     converged.
+
+
+Time step #78, advancing from t_n-1 = 0.77 to t = 0.78 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.364e-09        ---        4.08e-08        2       4.90e-10
+   4.900e-10     converged.
+
+
+Time step #79, advancing from t_n-1 = 0.78 to t = 0.79 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.401e-09        ILUs       5.10e-08        3       3.51e-10
+   3.513e-10     converged.
+
+
+Time step #80, advancing from t_n-1 = 0.79 to t = 0.8 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.539e-09        ---        4.16e-08        2       4.67e-10
+   4.675e-10     converged.
+
+
+Time step #81, advancing from t_n-1 = 0.8 to t = 0.81 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.310e-09        ILUs       5.03e-08        3       3.17e-10
+   3.173e-10     converged.
+
+-- Statistics --                    min      avg      max avg/call  p_min  p_max
+-- Statistics -- memory [MB] :      312      312      312           0      0     
+-- Statistics -- nln solver  :     2.39     2.39     2.39    0.239  0      0     
+-- Statistics --  lin solver :    0.841    0.841    0.841   0.0841  0      0     
+-- Statistics --   mat-vec   :    0.391    0.391    0.391  0.00909  0      0     
+-- Statistics --   full prec :    0.401    0.401    0.401  0.00933  0      0     
+-- Statistics --   velocity  :   0.0431   0.0431   0.0431    0.001  0      0     
+-- Statistics --   div matrix:    0.312    0.312    0.312  0.00725  0      0     
+-- Statistics --   pres mass :   0.0012   0.0012   0.0012 2.78e-05  0      0     
+-- Statistics --   pres Poiss:   0.0428   0.0428   0.0428 0.000995  0      0     
+
+
+Time step #82, advancing from t_n-1 = 0.81 to t = 0.82 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.544e-09        ---        3.66e-08        2       4.35e-10
+   4.346e-10     converged.
+
+
+Time step #83, advancing from t_n-1 = 0.82 to t = 0.83 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.167e-09        ILUs       4.68e-08        3       3.08e-10
+   3.085e-10     converged.
+
+
+Time step #84, advancing from t_n-1 = 0.83 to t = 0.84 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.492e-09        ---        3.47e-08        2       3.98e-10
+   3.983e-10     converged.
+
+
+Time step #85, advancing from t_n-1 = 0.84 to t = 0.85 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.074e-09        ILUs       3.56e-08        2       4.64e-10
+   4.641e-10     converged.
+
+
+Time step #86, advancing from t_n-1 = 0.85 to t = 0.86 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.217e-09        ---        3.61e-08        2       4.40e-10
+   4.396e-10     converged.
+
+
+Time step #87, advancing from t_n-1 = 0.86 to t = 0.87 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.278e-09        ILUs       4.43e-08        3       3.27e-10
+   3.271e-10     converged.
+
+
+Time step #88, advancing from t_n-1 = 0.87 to t = 0.88 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.320e-09        ---        3.67e-08        2       4.31e-10
+   4.306e-10     converged.
+
+
+Time step #89, advancing from t_n-1 = 0.88 to t = 0.89 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.214e-09        ILUs       3.73e-08        2       4.91e-10
+   4.907e-10     converged.
+
+
+Time step #90, advancing from t_n-1 = 0.89 to t = 0.9 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.258e-09        ---        3.78e-08        2       4.77e-10
+   4.775e-10     converged.
+
+
+Time step #91, advancing from t_n-1 = 0.9 to t = 0.91 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.293e-09        ILUs       5.00e-08        3       3.25e-10
+   3.251e-10     converged.
+
+-- Statistics --                    min      avg      max avg/call  p_min  p_max
+-- Statistics -- memory [MB] :      313      313      313           0      0     
+-- Statistics -- nln solver  :     2.37     2.37     2.37    0.237  0      0     
+-- Statistics --  lin solver :    0.785    0.785    0.785   0.0785  0      0     
+-- Statistics --   mat-vec   :    0.277    0.277    0.277  0.00643  0      0     
+-- Statistics --   full prec :     0.47     0.47     0.47   0.0109  0      0     
+-- Statistics --   velocity  :   0.0376   0.0376   0.0376 0.000874  0      0     
+-- Statistics --   div matrix:    0.401    0.401    0.401  0.00933  0      0     
+-- Statistics --   pres mass :  0.00123  0.00123  0.00123 2.86e-05  0      0     
+-- Statistics --   pres Poiss:   0.0288   0.0288   0.0288  0.00067  0      0     
+
+
+Time step #92, advancing from t_n-1 = 0.91 to t = 0.92 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.522e-09        ---        3.96e-08        2       4.63e-10
+   4.628e-10     converged.
+
+
+Time step #93, advancing from t_n-1 = 0.92 to t = 0.93 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.238e-09        ILUs       4.83e-08        3       3.13e-10
+   3.131e-10     converged.
+
+
+Time step #94, advancing from t_n-1 = 0.93 to t = 0.94 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.499e-09        ---        3.48e-08        2       4.28e-10
+   4.278e-10     converged.
+
+
+Time step #95, advancing from t_n-1 = 0.94 to t = 0.95 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.129e-09        ILUs       4.50e-08        3       3.13e-10
+   3.128e-10     converged.
+
+
+Time step #96, advancing from t_n-1 = 0.95 to t = 0.96 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.437e-09        ---        3.37e-08        2       3.98e-10
+   3.983e-10     converged.
+
+
+Time step #97, advancing from t_n-1 = 0.96 to t = 0.97 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.072e-09        ILUs       3.50e-08        2       4.72e-10
+   4.722e-10     converged.
+
+
+Time step #98, advancing from t_n-1 = 0.97 to t = 0.98 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.203e-09        ---        3.57e-08        2       4.57e-10
+   4.568e-10     converged.
+
+
+Time step #99, advancing from t_n-1 = 0.98 to t = 0.99 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.286e-09        ILUs       4.42e-08        3       3.36e-10
+   3.357e-10     converged.
+
+
+Time step #100, advancing from t_n-1 = 0.99 to t = 1 (dt = 0.01). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.326e-09        ---        3.71e-08        2       4.52e-10
+   4.523e-10     converged.
+
+
+
++-----------------------------------------------+------------+------------+
+| Total CPU time elapsed since start            |      43.4s |            |
+|                                               |            |            |
+| Section                           | no. calls |  CPU time  | % of total |
++-----------------------------------+-----------+------------+------------+
+| Generate output.                  |        51 |      8.35s |        19% |
+| NS apply boundary conditions.     |       100 |     0.203s |      0.47% |
+| NS assemble nonlinear residual.   |       202 |      2.64s |       6.1% |
+| NS assemble preconditioner.       |        50 |      18.5s |        43% |
+| NS build preconditioner.          |        50 |      1.18s |       2.7% |
+| NS distribute DoFs.               |         1 |    0.0318s |         0% |
+| NS setup matrix and vectors.      |         1 |    0.0818s |      0.19% |
+| NS solve system.                  |       102 |        12s |        28% |
+| Setup grid and initial condition. |         1 |    0.0372s |         0% |
++-----------------------------------+-----------+------------+------------+
+
+
+
++-----------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start      |        31s |            |
+|                                               |            |            |
+| Section                           | no. calls |  wall time | % of total |
++-----------------------------------+-----------+------------+------------+
+| Generate output.                  |        51 |      5.94s |        19% |
+| NS apply boundary conditions.     |       100 |     0.211s |      0.68% |
+| NS assemble nonlinear residual.   |       202 |      1.72s |       5.6% |
+| NS assemble preconditioner.       |        50 |      13.1s |        42% |
+| NS build preconditioner.          |        50 |      1.19s |       3.8% |
+| NS distribute DoFs.               |         1 |    0.0239s |         0% |
+| NS setup matrix and vectors.      |         1 |    0.0708s |      0.23% |
+| NS solve system.                  |       102 |      8.43s |        27% |
+| Setup grid and initial condition. |         1 |    0.0373s |      0.12% |
++-----------------------------------+-----------+------------+------------+
+

--- a/tests/1d_flow.prm
+++ b/tests/1d_flow.prm
@@ -1,0 +1,45 @@
+# --------------------------------------------------------------------------
+#
+# Copyright (C) 2013 - 2016 by the adaflo authors
+#
+# This file is part of the adaflo library.
+#
+# The adaflo library is free software; you can use it, redistribute it,
+# and/or modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation; either version 2.1 of the
+# License, or (at your option) any later version.  The full text of the
+# license can be found in the file LICENSE at the top level of the adaflo
+# distribution.
+#
+# --------------------------------------------------------------------------
+# Listing of Parameters
+subsection Time stepping
+  set scheme           = bdf_2
+  set end time         = 1
+  set step size        = 0.001
+end
+subsection Navier-Stokes
+  set physical type      = incompressible
+  set dimension          = 1
+  set velocity degree    = 2
+  set density            = 0.0
+  set viscosity          = 1.0
+  subsection Solver
+    set linearization scheme         = coupled implicit Newton
+    set NL max iterations            = 10
+    set NL tolerance                 = 1.e-9
+    set lin max iterations           = 30
+    set lin tolerance                = 1.e-5
+    set lin relative tolerance       = 1
+    set lin velocity preconditioner  = ilu scalar
+    set lin pressure mass preconditioner = ilu
+    set lin its before inner solvers = 30
+    set tau grad div = 1.e-5
+  end
+end
+subsection Output options
+  set output verbosity = 2
+  set output frequency = 0.02
+  set output filename  = output-1d_flow/data
+  set output vtk files = 1
+end

--- a/tests/1d_flow.prm
+++ b/tests/1d_flow.prm
@@ -16,14 +16,14 @@
 subsection Time stepping
   set scheme           = bdf_2
   set end time         = 1
-  set step size        = 0.001
+  set step size        = 0.01
 end
 subsection Navier-Stokes
   set physical type      = incompressible
   set dimension          = 1
   set velocity degree    = 2
-  set density            = 0.0
-  set viscosity          = 1.0
+  set density            = 1.0
+  set viscosity          = 0.01
   subsection Solver
     set linearization scheme         = coupled implicit Newton
     set NL max iterations            = 10

--- a/tests/couette.cc
+++ b/tests/couette.cc
@@ -1,0 +1,303 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (C) 2011 - 2016 by the adaflo authors
+//
+// This file is part of the adaflo library.
+//
+// The adaflo library is free software; you can use it, redistribute it,
+// and/or modify it under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation; either version 2.1 of the
+// License, or (at your option) any later version.  The full text of the
+// license can be found in the file LICENSE at the top level of the adaflo
+// distribution.
+//
+// --------------------------------------------------------------------------
+
+#include <deal.II/base/function.h>
+#include <deal.II/base/function_time.h>
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/parameter_handler.h>
+#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/grid_refinement.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_in.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/vector_tools.h>
+
+#include <adaflo/navier_stokes.h>
+#include <adaflo/time_stepping.h>
+
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+
+using namespace dealii;
+
+
+
+// @sect4{Exact Solution}
+
+template <int dim>
+class ExactSolutionU : public Function<dim>
+{
+public:
+  ExactSolutionU(const double viscosity = 1., const double time = 0.)
+    : Function<dim>(dim, time)
+    , nu(viscosity)
+  {}
+
+  virtual void
+  vector_value(const Point<dim> &p, Vector<double> &values) const;
+
+private:
+  const double nu;
+};
+
+template <int dim>
+void
+ExactSolutionU<dim>::vector_value(const Point<dim> &p, Vector<double> &values) const
+{
+  AssertDimension(values.size(), dim);
+
+  // exact solution for channel flow in time-dependent setting is
+  // approximately computed from an ODE of the form ds/dt + nu s - 1 = 0
+  // with initial condition s(0) = 0, which gives the x-velocity of the form
+  // u(x,y,t) = s(t) * (1-y)*(1+y) assuming a quadratic profile. But the
+  // profile will only be quadratic in the steady state, so only use it for
+  // the steady state
+  // const double time = this->get_time();
+
+  values(0) = 0.5 / nu * (1 - p[1]) * (1 + p[1]);
+  for (unsigned int d = 1; d < dim; ++d)
+    values(d) = 0;
+}
+
+
+
+template <int dim>
+class ExactSolutionP : public Function<dim>
+{
+public:
+  ExactSolutionP()
+    : Function<dim>(1, 0)
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int) const;
+};
+
+template <int dim>
+double
+ExactSolutionP<dim>::value(const Point<dim> &p, const unsigned int) const
+{
+  return 2 - p[0];
+}
+
+
+
+// @sect3{The <code>Beltramiproblem</code> class template}
+template <int dim>
+class CouetteProblem
+{
+public:
+  CouetteProblem(const FlowParameters &parameters);
+  void
+  run();
+
+private:
+  void
+  compute_errors() const;
+  void
+  output_results() const;
+
+  ConditionalOStream pcout;
+
+  mutable TimerOutput timer;
+
+  parallel::distributed::Triangulation<dim> triangulation;
+  NavierStokes<dim>                         navier_stokes;
+  const double                              nu;
+
+  const unsigned int output_timestep_skip;
+};
+
+
+
+template <int dim>
+CouetteProblem<dim>::CouetteProblem(const FlowParameters &parameters)
+  : pcout(std::cout, (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0))
+  , timer(pcout, TimerOutput::summary, TimerOutput::cpu_and_wall_times)
+  , triangulation(MPI_COMM_WORLD)
+  , navier_stokes(parameters, triangulation, &timer)
+  , nu(parameters.viscosity)
+  , output_timestep_skip(4)
+{}
+
+
+
+template <int dim>
+void
+CouetteProblem<dim>::output_results() const
+{
+  ExactSolutionU<dim> exact(nu, navier_stokes.time_stepping.now());
+  Vector<double>      values(dim);
+  exact.vector_value(Point<dim>(), values);
+
+  pcout << "  Maximum velocity now: " << values[0] << std::endl;
+
+  navier_stokes.output_solution(navier_stokes.get_parameters().output_filename);
+}
+
+
+
+template <int dim>
+void
+CouetteProblem<dim>::run()
+{
+  timer.enter_subsection("Setup grid and initial condition.");
+  pcout << "Running a " << dim << "D channel flow problem "
+        << "using " << navier_stokes.time_stepping.name() << ", Q"
+        << navier_stokes.get_fe_u().degree << "/Q" << navier_stokes.get_fe_p().degree
+        << " elements" << std::endl;
+
+  std::vector<unsigned int> subdivisions(dim, 1);
+  subdivisions[0] = 4;
+
+  const Point<dim> bottom_left = (dim == 2 ? Point<dim>(-2, -1) : Point<dim>(-2, -1, -1));
+  const Point<dim> top_right   = (dim == 2 ? Point<dim>(2, 0) : Point<dim>(2, 0, 0));
+
+  GridGenerator::subdivided_hyper_rectangle(triangulation,
+                                            subdivisions,
+                                            bottom_left,
+                                            top_right);
+
+  // no need to check for owned cells here: on level 0 everything is locally
+  // owned
+  for (typename Triangulation<dim>::active_cell_iterator it = triangulation.begin();
+       it != triangulation.end();
+       ++it)
+    for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
+      if (it->face(face)->at_boundary() &&
+          std::abs(it->face(face)->center()[0] - 2) < 1e-13)
+        it->face(face)->set_boundary_id(1); // left
+      else if (it->face(face)->at_boundary() &&
+               std::abs(it->face(face)->center()[0] + 2) < 1e-13)
+        it->face(face)->set_boundary_id(2); // right
+      else if (it->face(face)->at_boundary() &&
+               std::abs(it->face(face)->center()[1]) < 1e-13)
+        it->face(face)->set_boundary_id(3); // top
+
+
+  navier_stokes.set_no_slip_boundary(0);
+
+  const std::vector<double> vel = {2, 0};
+  navier_stokes.set_velocity_dirichlet_boundary(
+    3, std::make_shared<Functions::ConstantFunction<dim>>(vel));
+
+  navier_stokes.set_open_boundary_with_normal_flux(
+    1, std::make_shared<Functions::ZeroFunction<dim>>());
+  navier_stokes.set_open_boundary_with_normal_flux(
+    2, std::make_shared<Functions::ZeroFunction<dim>>());
+  timer.leave_subsection();
+
+  navier_stokes.setup_problem(Functions::ZeroFunction<dim>(dim));
+  navier_stokes.print_n_dofs();
+  output_results();
+
+  // @sect5{Time loop}
+  if (navier_stokes.get_parameters().physical_type == FlowParameters::incompressible)
+    while (navier_stokes.time_stepping.at_end() == false)
+      {
+        navier_stokes.advance_time_step();
+
+        // We check whether we are at a time step where to save the current
+        // solution to a file.
+        if (navier_stokes.time_stepping.step_no() % output_timestep_skip == 0)
+          output_results();
+      }
+  else
+    navier_stokes.advance_time_step();
+}
+
+
+
+/* ----------------------------------------------------------------------- */
+
+
+
+/* ----------------------------------------------------------------------- */
+
+
+
+int
+main(int argc, char **argv)
+{
+  /* we initialize MPI at the start of the program. Since we will in general mix
+   * MPI parallelization with threads, we also set the third argument in MPI_InitFinalize
+   * that controls the number of threads to an invalid number, which means that the TBB
+   * library chooses the number of threads automatically, typically to the number of
+   * available cores in the system. As an alternative, you can also set this number
+   * manually if you want to set a specific number of threads (e.g. when MPI-only is
+   * required)  (cf step-40 and 48).
+   */
+  try
+    {
+      using namespace dealii;
+
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(
+        argc, argv, 1); // numbers::invalid_unsigned_int);
+      deallog.depth_console(0);
+
+      std::string paramfile;
+      if (argc > 1)
+        paramfile = argv[1];
+      else
+        paramfile = "couette.prm";
+
+      FlowParameters parameters(paramfile);
+      Assert(parameters.dimension == 2, ExcNotImplemented());
+
+      CouetteProblem<2> channel(parameters);
+      channel.run();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------" << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------" << std::endl;
+
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------" << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------" << std::endl;
+      return 1;
+    }
+
+  return 0;
+}

--- a/tests/couette.output
+++ b/tests/couette.output
@@ -1,0 +1,69 @@
+Running a 2D Couette problem using BDF-2, Q2/Q1 elements
+ Number of active cells: 1024.
+ Number of degrees of freedom (velocity/pressure): 9619 (8514 + 1105).
+ Approximate size last cell: 0.0625
+
+Time step #1, advancing from t_n-1 = 0 to t = 0.5 (dt = 0.5). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.601e+01        AMG        5.83e+01       18       9.29e-06
+   9.320e-06        ---        1.17e-03       23       5.66e-11
+   5.675e-11        ---        6.02e-09       10       4.10e-13
+   4.122e-13     converged.
+
+-- Statistics --                    min      avg      max avg/call  p_min  p_max
+-- Statistics -- memory [MB] :      292      293      294           2      0     
+-- Statistics -- nln solver  :    0.613    0.613    0.613    0.613  0      1     
+-- Statistics --  lin solver :    0.488    0.488    0.488    0.163  0      2     
+-- Statistics --   mat-vec   :    0.096   0.0961   0.0961  0.00169  0      1     
+-- Statistics --   full prec :    0.374    0.375    0.375  0.00657  1      0     
+-- Statistics --   velocity  :    0.339    0.339    0.339  0.00595  1      0     
+-- Statistics --   div matrix:   0.0274   0.0275   0.0276 0.000483  3      2     
+-- Statistics --   pres mass : 0.000549 0.000561 0.000569 9.84e-06  1      3     
+-- Statistics --   pres Poiss:  0.00682  0.00702  0.00719 0.000123  1      0     
+
+
+Time step #2, advancing from t_n-1 = 0.5 to t = 1 (dt = 0.5). 
+
+   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
+   ____________________________________________________________
+   1.930e-01        AMG        1.60e+01       19       1.44e-06
+   1.444e-06        ---        1.86e-04       21       1.41e-11
+   1.414e-11        ---        1.14e-09        7       3.41e-13
+   3.437e-13     converged.
+
+
+
++-----------------------------------------------+------------+------------+
+| Total CPU time elapsed since start            |      1.54s |            |
+|                                               |            |            |
+| Section                           | no. calls |  CPU time  | % of total |
++-----------------------------------+-----------+------------+------------+
+| NS apply boundary conditions.     |         2 |    0.0283s |       1.8% |
+| NS assemble nonlinear residual.   |         8 |    0.0194s |       1.3% |
+| NS assemble preconditioner.       |         2 |     0.131s |       8.5% |
+| NS build preconditioner.          |         2 |    0.0935s |       6.1% |
+| NS distribute DoFs.               |         1 |    0.0428s |       2.8% |
+| NS setup matrix and vectors.      |         1 |    0.0395s |       2.6% |
+| NS solve system.                  |         6 |     0.939s |        61% |
+| Setup grid and initial condition. |         1 |   0.00847s |      0.55% |
++-----------------------------------+-----------+------------+------------+
+
+
+
++-----------------------------------------------+------------+------------+
+| Total wallclock time elapsed since start      |      1.54s |            |
+|                                               |            |            |
+| Section                           | no. calls |  wall time | % of total |
++-----------------------------------+-----------+------------+------------+
+| NS apply boundary conditions.     |         2 |    0.0283s |       1.8% |
+| NS assemble nonlinear residual.   |         8 |    0.0196s |       1.3% |
+| NS assemble preconditioner.       |         2 |     0.131s |       8.5% |
+| NS build preconditioner.          |         2 |    0.0959s |       6.2% |
+| NS distribute DoFs.               |         1 |    0.0428s |       2.8% |
+| NS setup matrix and vectors.      |         1 |    0.0396s |       2.6% |
+| NS solve system.                  |         6 |      0.94s |        61% |
+| Setup grid and initial condition. |         1 |   0.00849s |      0.55% |
++-----------------------------------+-----------+------------+------------+
+

--- a/tests/couette.prm
+++ b/tests/couette.prm
@@ -1,0 +1,42 @@
+# --------------------------------------------------------------------------
+#
+# Copyright (C) 2013 - 2016 by the adaflo authors
+#
+# This file is part of the adaflo library.
+#
+# The adaflo library is free software; you can use it, redistribute it,
+# and/or modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation; either version 2.1 of the
+# License, or (at your option) any later version.  The full text of the
+# license can be found in the file LICENSE at the top level of the adaflo
+# distribution.
+#
+# --------------------------------------------------------------------------
+#
+# Listing of Parameters
+subsection Time stepping
+  set end time   = 20
+  set step size  = 0.5
+end
+subsection Navier-Stokes
+  set physical type      = incompressible
+  set dimension          = 2
+  set global refinements = 4
+  set velocity degree    = 2
+  set viscosity          = 0.5
+  subsection Solver
+    set linearization scheme         = coupled implicit Newton
+    set NL max iterations            = 10
+    set NL tolerance                 = 1.e-12
+    set lin max iterations           = 50
+    set lin tolerance                = 1.e-5
+    set lin relative tolerance       = 1
+    set lin velocity preconditioner  = amg
+    set lin its before inner solvers = 50
+  end
+end
+subsection Output options
+  set output verbosity = 2
+  set output vtk files = 1
+  set output filename = output-couette/data
+end

--- a/tests/couette.prm
+++ b/tests/couette.prm
@@ -15,7 +15,7 @@
 #
 # Listing of Parameters
 subsection Time stepping
-  set end time   = 20
+  set end time   = 1.0
   set step size  = 0.5
 end
 subsection Navier-Stokes
@@ -37,6 +37,7 @@ subsection Navier-Stokes
 end
 subsection Output options
   set output verbosity = 2
+  set output frequency = 0.5
   set output vtk files = 1
   set output filename = output-couette/data
 end


### PR DESCRIPTION
This PR enables to solve 1d-Navier-Stokes problems, which makes the integration of Adaflo into `MeltPoolDG` also for `dim==1` straightforward. It depends on PR [#11914](https://github.com/dealii/dealii/pull/11914) of deal.II. I added two test cases
-  `1d_flow.cc` for testing the 1d-implementation (although it is very boring :-))
-  `couette.cc` due to personal interest
![image](https://user-images.githubusercontent.com/70260016/111866955-32b58a00-8971-11eb-8b96-761e2e8a3e68.png)


