### PR TITLE
SIM: rising bubble fixes

### DIFF
--- a/include/adaflo/sharp_interface.h
+++ b/include/adaflo/sharp_interface.h
@@ -973,14 +973,14 @@ private:
     else if (!use_auxiliary_surface_mesh && !use_sharp_interface)
       compute_force_vector_regularized(
         level_set_solver.get_matrix_free(),
-        level_set_solver.get_level_set_vector(),
-        level_set_solver.get_curvature_vector(),
-        navier_stokes_solver.user_rhs.block(0),
         LevelSetSolver<dim>::dof_index_ls,
         LevelSetSolver<dim>::dof_index_curvature,
         LevelSetSolver<dim>::dof_index_velocity,
         LevelSetSolver<dim>::quad_index_vel,
-        navier_stokes_solver.get_parameters().surface_tension);
+        navier_stokes_solver.get_parameters().surface_tension,
+        level_set_solver.get_level_set_vector(),
+        level_set_solver.get_curvature_vector(),
+        navier_stokes_solver.user_rhs.block(0));
     else
       AssertThrow(false, ExcNotImplemented());
   }

--- a/include/adaflo/sharp_interface.h
+++ b/include/adaflo/sharp_interface.h
@@ -955,9 +955,9 @@ private:
         navier_stokes_solver.mapping,
         level_set_solver.get_dof_handler(),
         navier_stokes_solver.get_dof_handler_u(),
+        navier_stokes_solver.get_parameters().surface_tension,
         level_set_solver.get_normal_vector(),
         level_set_solver.get_curvature_vector(),
-        navier_stokes_solver.get_parameters().surface_tension,
         navier_stokes_solver.user_rhs.block(0));
     else if (!use_auxiliary_surface_mesh && use_sharp_interface)
       compute_force_vector_sharp_interface(
@@ -965,10 +965,10 @@ private:
         navier_stokes_solver.mapping,
         level_set_solver.get_dof_handler(),
         navier_stokes_solver.get_dof_handler_u(),
+        navier_stokes_solver.get_parameters().surface_tension,
         level_set_solver.get_normal_vector(),
         level_set_solver.get_curvature_vector(),
         level_set_solver.get_level_set_vector(),
-        navier_stokes_solver.get_parameters().surface_tension,
         navier_stokes_solver.user_rhs.block(0));
     else if (!use_auxiliary_surface_mesh && !use_sharp_interface)
       compute_force_vector_regularized(

--- a/include/adaflo/sharp_interface_util.h
+++ b/include/adaflo/sharp_interface_util.h
@@ -1072,14 +1072,14 @@ compute_force_vector_sharp_interface(const Quadrature<dim - 1> &surface_quad,
 template <int dim, typename VectorType1, typename VectorType2>
 void
 compute_force_vector_regularized(const MatrixFree<dim, double> &matrix_free,
-                                 const VectorType1 &            ls_solution,
-                                 const VectorType1 &            curvature_solution,
-                                 VectorType2 &                  force_rhs,
                                  const unsigned int             dof_index_ls,
                                  const unsigned int             dof_index_curvature,
                                  const unsigned int             dof_index_normal,
                                  const unsigned int             quad_index,
-                                 const double surface_tension_coefficient)
+                                 const double       surface_tension_coefficient,
+                                 const VectorType1 &ls_solution,
+                                 const VectorType1 &curvature_solution,
+                                 VectorType2 &      force_rhs)
 {
   (void)matrix_free;
   (void)ls_solution;

--- a/include/adaflo/sharp_interface_util.h
+++ b/include/adaflo/sharp_interface_util.h
@@ -524,6 +524,9 @@ collect_integration_points(
 
 
 
+/**
+ * Compute force vector for sharp-interface method (front tracking).
+ */
 template <int dim, int spacedim, typename VectorType>
 void
 compute_force_vector_sharp_interface(
@@ -803,6 +806,9 @@ collect_evaluation_points(const Triangulation<dim, spacedim> &     surface_mesh,
 
 
 
+/**
+ * Compute force vector for sharp-interface method (mixed level set).
+ */
 template <int dim, typename VectorType, typename BlockVectorType>
 void
 compute_force_vector_sharp_interface(const Triangulation<dim - 1, dim> &surface_mesh,
@@ -812,9 +818,9 @@ compute_force_vector_sharp_interface(const Triangulation<dim - 1, dim> &surface_
                                      const Mapping<dim> &               mapping,
                                      const DoFHandler<dim> &            dof_handler,
                                      const DoFHandler<dim> &            dof_handler_dim,
+                                     const double                       surface_tension,
                                      const BlockVectorType &normal_vector_field,
                                      const VectorType &     curvature_solution,
-                                     const double           surface_tension,
                                      VectorType &           force_vector)
 {
   // step 1) collect all locally-relevant surface quadrature points (cell,
@@ -916,16 +922,19 @@ compute_force_vector_sharp_interface(const Triangulation<dim - 1, dim> &surface_
 
 
 
+/**
+ * Compute force vector for sharp-interface method (marching-cube algorithm).
+ */
 template <int dim, typename VectorType, typename BlockVectorType>
 void
 compute_force_vector_sharp_interface(const Quadrature<dim - 1> &surface_quad,
                                      const Mapping<dim> &       mapping,
                                      const DoFHandler<dim> &    dof_handler,
                                      const DoFHandler<dim> &    dof_handler_dim,
+                                     const double               surface_tension,
                                      const BlockVectorType &    normal_vector_field,
                                      const VectorType &         curvature_solution,
                                      const VectorType &         ls_vector,
-                                     const double               surface_tension,
                                      VectorType &               force_vector)
 {
   const unsigned int                        n_subdivisions = 3;
@@ -1060,12 +1069,12 @@ compute_force_vector_sharp_interface(const Quadrature<dim - 1> &surface_quad,
 
 
 
-template <int dim, typename VectorType1>
+template <int dim, typename VectorType1, typename VectorType2>
 void
 compute_force_vector_regularized(const MatrixFree<dim, double> &matrix_free,
                                  const VectorType1 &            ls_solution,
                                  const VectorType1 &            curvature_solution,
-                                 VectorType1 &                  force_rhs,
+                                 VectorType2 &                  force_rhs,
                                  const unsigned int             dof_index_ls,
                                  const unsigned int             dof_index_curvature,
                                  const unsigned int             dof_index_normal,
@@ -1080,7 +1089,7 @@ compute_force_vector_regularized(const MatrixFree<dim, double> &matrix_free,
   level_set_as_heaviside.add(1.0);
   level_set_as_heaviside *= 0.5;
 
-  matrix_free.template cell_loop<VectorType1, VectorType1>(
+  matrix_free.template cell_loop<VectorType2, VectorType1>(
     [&](const auto &matrix_free,
         auto &      force_rhs,
         const auto &level_set_as_heaviside,

--- a/tests/sharp_interfaces_01.cc
+++ b/tests/sharp_interfaces_01.cc
@@ -359,14 +359,14 @@ test(const std::string &parameter_filename)
 
   //  compute force vector with a regularized approach
   compute_force_vector_regularized(matrix_free,
-                                   ls_solution,
-                                   curvature_solution,
-                                   force_vector_regularized,
                                    dof_index_ls,
                                    dof_index_curvature,
                                    dof_index_normal,
                                    quad_index,
-                                   1.0 /*TODO*/);
+                                   1.0, /*TODO*/
+                                   ls_solution,
+                                   curvature_solution,
+                                   force_vector_regularized);
 
   std::cout << force_vector_regularized.l2_norm() << std::endl;
 
@@ -478,14 +478,14 @@ test(const std::string &parameter_filename)
         force_vector_regularized, LevelSetSolver<dim>::dof_index_velocity);
 
       compute_force_vector_regularized(level_set_solver.get_matrix_free(),
-                                       level_set_solver.get_level_set_vector(),
-                                       level_set_solver.get_curvature_vector(),
-                                       force_vector_regularized,
                                        LevelSetSolver<dim>::dof_index_ls,
                                        LevelSetSolver<dim>::dof_index_curvature,
                                        LevelSetSolver<dim>::dof_index_velocity,
                                        LevelSetSolver<dim>::quad_index,
-                                       1.0 /*TODO*/);
+                                       1.0, /*TODO*/
+                                       level_set_solver.get_level_set_vector(),
+                                       level_set_solver.get_curvature_vector(),
+                                       force_vector_regularized);
 
       // sharp interface
       VectorType force_vector_sharp_interface;

--- a/tests/sharp_interfaces_01.cc
+++ b/tests/sharp_interfaces_01.cc
@@ -365,7 +365,8 @@ test(const std::string &parameter_filename)
                                    dof_index_ls,
                                    dof_index_curvature,
                                    dof_index_normal,
-                                   quad_index);
+                                   quad_index,
+                                   1.0 /*TODO*/);
 
   std::cout << force_vector_regularized.l2_norm() << std::endl;
 
@@ -393,6 +394,7 @@ test(const std::string &parameter_filename)
                                             mapping,
                                             dof_handler,
                                             dof_handler_dim,
+                                            1.0, /*TODO*/
                                             normal_vector_field,
                                             curvature_solution,
                                             force_vector_sharp_interface);
@@ -482,7 +484,8 @@ test(const std::string &parameter_filename)
                                        LevelSetSolver<dim>::dof_index_ls,
                                        LevelSetSolver<dim>::dof_index_curvature,
                                        LevelSetSolver<dim>::dof_index_velocity,
-                                       LevelSetSolver<dim>::quad_index);
+                                       LevelSetSolver<dim>::quad_index,
+                                       1.0 /*TODO*/);
 
       // sharp interface
       VectorType force_vector_sharp_interface;
@@ -496,6 +499,7 @@ test(const std::string &parameter_filename)
                                                 mapping,
                                                 level_set_solver.get_dof_handler(),
                                                 level_set_solver.get_dof_handler_dim(),
+                                                1.0, /*TODO*/
                                                 level_set_solver.get_normal_vector(),
                                                 level_set_solver.get_curvature_vector(),
                                                 force_vector_sharp_interface);

--- a/tests/sharp_interfaces_04.prm
+++ b/tests/sharp_interfaces_04.prm
@@ -16,7 +16,7 @@
 #
 # mpirun: 2
 subsection Problem-specific
-  set two-phase method = mixed level set
+  set two-phase method = sharp level set
 end
 subsection Two phase
   set density              = 1.


### PR DESCRIPTION
- set correct surface-tension coefficient
- reorder DoFs in velocity field
- `compute_force_vector_regularized()`: do not zero out destination vector