### PR TITLE
Include missing LAPACK header

### DIFF
--- a/include/adaflo/util.h
+++ b/include/adaflo/util.h
@@ -18,6 +18,8 @@
 
 #include <deal.II/distributed/tria.h>
 
+#include <deal.II/lac/lapack_full_matrix.h>
+
 #include <deal.II/matrix_free/matrix_free.h>
 
 using namespace dealii;


### PR DESCRIPTION
`adaflo` did not compile after the change https://github.com/dealii/dealii/commit/917da14d174fdde3cef8ac6b53f93bff3863e7bc#diff-bd8e2544cbe8df08d2c12ae4df4230f1a71ad69a32235324b42ebd0ec4f1eb6b in deal.II. This PR fixes the compilation error by including the corresponding LAPACK header.