### PR TITLE
Add input parameter for the formulation of the convective term

### DIFF
--- a/include/adaflo/parameters.h
+++ b/include/adaflo/parameters.h
@@ -57,6 +57,13 @@ struct FlowParameters
     incompressible_stationary,
     stokes
   } physical_type;
+
+  std::map<std::string, double> get_beta_formulation_convective_term_momentum_balance = {
+    {"conservative", 1.0},
+    {"convective", 0.0},
+    {"skew-symmetric", 0.5},
+  };
+  double       beta_convective_term_momentum_balance;
   unsigned int velocity_degree;
   bool         augmented_taylor_hood;
   double       viscosity;

--- a/source/navier_stokes_matrix.cc
+++ b/source/navier_stokes_matrix.cc
@@ -637,10 +637,11 @@ NavierStokesMatrix<dim>::local_operation(
     parameters.linearization == FlowParameters::coupled_velocity_semi_implicit ||
     parameters.linearization == FlowParameters::coupled_velocity_explicit;
 
-  // 0:   NS in convective form
-  // 0.5: NS in skew-symmetric form
-  // 1:   NS in conservative form
-  const vector_t conservative_form = make_vectorized_array<double>(0.5);
+  // beta = 0:   NS in convective form     ∇•(u x u) = (u • ∇) u
+  // beta = 0.5: NS in skew-symmetric form ∇•(u x u) = (u • ∇) u + 0.5 u (∇ • u) (default)
+  // beta = 1:   NS in conservative form   ∇•(u x u) = (u • ∇) u + u (∇ • u)
+  const vector_t conservative_form =
+    make_vectorized_array<double>(parameters.beta_convective_term_momentum_balance);
 
   for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
     {

--- a/source/parameters.cc
+++ b/source/parameters.cc
@@ -117,6 +117,15 @@ FlowParameters::declare_parameters(ParameterHandler &prm)
                     "Navier-Stokes, one can choose between a stationary and a "
                     "time-dependent variant. The time-dependent Navier-Stokes "
                     "equations are the default.");
+  prm.declare_entry("formulation convective term momentum balance",
+                    "skew-symmetric",
+                    Patterns::Selection("skew-symmetric|convective|conservative"),
+                    "Sets the formulation of the convective term in the "
+                    "momentum balance of the Navier-Stokes equations, i.e. "
+                    "∇·(u x u) =(u·∇)u + βu(∇·u). The parameter β will be "
+                    "set to 1 for the conservative form, to 0 for the "
+                    "convective form and to 0.5 for the the skew-symmetric "
+                    "form (default formulation).");
 
   prm.enter_subsection("Solver");
   prm.declare_entry("NL max iterations",
@@ -456,8 +465,9 @@ FlowParameters::parse_parameters(ParameterHandler &prm)
     Assert(false, ExcNotImplemented());
   if (physical_type == stokes)
     density = 0;
-
-
+  beta_convective_term_momentum_balance =
+    get_beta_formulation_convective_term_momentum_balance[prm.get(
+      "formulation convective term momentum balance")];
 
   prm.enter_subsection("Solver");
   max_nl_iteration   = prm.get_integer("NL max iterations");

--- a/source/parameters.cc
+++ b/source/parameters.cc
@@ -124,7 +124,7 @@ FlowParameters::declare_parameters(ParameterHandler &prm)
                     "momentum balance of the Navier-Stokes equations, i.e. "
                     "∇·(u x u) =(u·∇)u + βu(∇·u). The parameter β will be "
                     "set to 1 for the conservative form, to 0 for the "
-                    "convective form and to 0.5 for the the skew-symmetric "
+                    "convective form and to 0.5 for the skew-symmetric "
                     "form (default formulation).");
 
   prm.enter_subsection("Solver");


### PR DESCRIPTION
This PR introduces an input parameter to choose the formulation for the convective term in the momentum balance of the Navier-Stokes equations. By default the skew-symmetric formulation is set. As I switched to the convective formulation, I could "fix" the numerical solution for the pressure in the example for two-phase-flow with evaporation:

![stefans_problem_influence_density](https://user-images.githubusercontent.com/70260016/114391503-dcb2bb80-9b97-11eb-96bb-3057bc570364.png)

Thank you @kronbichler and @peterrum for the discussion, your ideas helped a lot and make me very happy right now :-).