### PR TITLE
Fix linking error GeometryInfo::vertices_per_cell

### DIFF
--- a/include/adaflo/navier_stokes_preconditioner.h
+++ b/include/adaflo/navier_stokes_preconditioner.h
@@ -200,7 +200,7 @@ private:
     unsigned int n_subelements_u;
     unsigned int n_subelements_p;
 
-    static const unsigned int              n_dofs = GeometryInfo<dim>::vertices_per_cell;
+    static constexpr unsigned int          n_dofs = GeometryInfo<dim>::vertices_per_cell;
     Tensor<1, dim>                         grads_unit_cell[n_dofs][n_dofs];
     double                                 values_unit_cell[n_dofs][n_dofs];
     std::vector<std::vector<unsigned int>> dof_to_lin_u;


### PR DESCRIPTION
This PR fixes a linking error to `dealii::GeometryInfo::vertices_per_cell`, which occurred only in debug mode. The linking error might be related to a PR in deal.II of the last two days, however, unfortunately, I could not identify it.