### PR TITLE
Add reference to range-based for loop

### DIFF
--- a/source/level_set_okz_advance_concentration.cc
+++ b/source/level_set_okz_advance_concentration.cc
@@ -583,7 +583,7 @@ LevelSetOKZSolverAdvanceConcentration<dim>::advance_concentration(const double d
                                                   this->parameters.dof_index_ls);
             cell_rhs = 0;
 
-            for (const auto face : cell->face_iterators())
+            for (const auto &face : cell->face_iterators())
               {
                 if (face->at_boundary() == false)
                   continue;


### PR DESCRIPTION
This PR fixes a compiler warning by introducing a missing `&`.