### PR TITLE
Add damping contribution to NavierStokesPreconditioner

### DIFF
--- a/include/adaflo/navier_stokes_matrix.h
+++ b/include/adaflo/navier_stokes_matrix.h
@@ -266,7 +266,9 @@ private:
 
   mutable AlignedVector<VectorizedArray<double>> variable_densities_preconditioner;
   mutable AlignedVector<VectorizedArray<double>> variable_viscosities_preconditioner;
-  mutable AlignedVector<velocity_stored>         linearized_velocities_preconditioner;
+  mutable AlignedVector<VectorizedArray<double>>
+                                         variable_damping_coefficients_preconditioner;
+  mutable AlignedVector<velocity_stored> linearized_velocities_preconditioner;
 
   const LinearAlgebra::distributed::BlockVector<double> &solution_old;
   const LinearAlgebra::distributed::BlockVector<double> &solution_old_old;

--- a/source/navier_stokes_matrix.cc
+++ b/source/navier_stokes_matrix.cc
@@ -182,6 +182,7 @@ NavierStokesMatrix<dim>::clear()
   linearized_velocities.clear();
   variable_densities_preconditioner.clear();
   variable_viscosities_preconditioner.clear();
+  variable_damping_coefficients_preconditioner.clear();
   linearized_velocities_preconditioner.clear();
 }
 
@@ -349,6 +350,7 @@ NavierStokesMatrix<dim>::velocity_vmult(
       linearized_velocities.swap(linearized_velocities_preconditioner);
       variable_densities.swap(variable_densities_preconditioner);
       variable_viscosities.swap(variable_viscosities_preconditioner);
+      variable_damping_coefficients.swap(variable_damping_coefficients_preconditioner);
     }
 
 #define OPERATION(degree_p)                                                  \
@@ -368,6 +370,7 @@ NavierStokesMatrix<dim>::velocity_vmult(
       linearized_velocities.swap(linearized_velocities_preconditioner);
       variable_densities.swap(variable_densities_preconditioner);
       variable_viscosities.swap(variable_viscosities_preconditioner);
+      variable_damping_coefficients.swap(variable_damping_coefficients_preconditioner);
     }
 
   // diagonal values of constrained degrees of freedom set to 1
@@ -1131,9 +1134,10 @@ template <int dim>
 void
 NavierStokesMatrix<dim>::fix_linearization_point() const
 {
-  linearized_velocities_preconditioner = linearized_velocities;
-  variable_densities_preconditioner    = variable_densities;
-  variable_viscosities_preconditioner  = variable_viscosities;
+  linearized_velocities_preconditioner         = linearized_velocities;
+  variable_densities_preconditioner            = variable_densities;
+  variable_viscosities_preconditioner          = variable_viscosities;
+  variable_damping_coefficients_preconditioner = variable_damping_coefficients;
 }
 
 
@@ -1148,6 +1152,7 @@ NavierStokesMatrix<dim>::memory_consumption() const
   memory += linearized_velocities_preconditioner.size();
   memory += variable_densities_preconditioner.size();
   memory += variable_viscosities_preconditioner.size();
+  memory += variable_damping_coefficients_preconditioner.size();
   return memory;
 }
 
@@ -1163,11 +1168,13 @@ NavierStokesMatrix<dim>::print_memory_consumption(std::ostream &stream) const
          << " MB\n";
   if (variable_viscosities.size() > 0)
     stream << "| Variable densities & viscosities: "
-           << 1e-6 * double(variable_densities.memory_consumption() +
-                            variable_viscosities.memory_consumption() +
-                            variable_damping_coefficients.memory_consumption() +
-                            variable_densities_preconditioner.memory_consumption() +
-                            variable_viscosities_preconditioner.memory_consumption())
+           << 1e-6 *
+                double(variable_densities.memory_consumption() +
+                       variable_viscosities.memory_consumption() +
+                       variable_damping_coefficients.memory_consumption() +
+                       variable_densities_preconditioner.memory_consumption() +
+                       variable_viscosities_preconditioner.memory_consumption() +
+                       variable_damping_coefficients_preconditioner.memory_consumption())
            << " MB\n";
 }
 


### PR DESCRIPTION
This PR adds the contribution of the damping term to the `NavierStokesPreconditioner`. I've conducted a performance study based on our melt pool simulations, where half of the domain is solid with a damping coefficient of 1e10:

- Including the damping terms in the ILU preconditioner reduces the number of linear iterations. 
- Including the damping terms in the AMG preconditioner yields (unfortunately) a slight increase in the number of linear iterations. It could be that I missed here something in the implementation.

@nmuch: FYI

**ILU original:**
```
Time step #150, advancing from t_n-1 = 1.49e-05 to t = 1.5e-05 (dt = 1e-07).

   NL Resid u  NL Resid p     Prec Upd     Increm u   Increm p   Lin Iter     Lin Res
   __________________________________________________________________________________
   3.224e-04   9.271e-18        ---        1.30e-03   1.46e+02      18       3.16e-07
   3.163e-07   1.806e-12        ---        5.40e-06   5.03e+01      34       2.89e-10
   2.891e-10   2.426e-15        ---        1.96e-09   8.13e-03      34       4.92e-13
   4.917e-13   4.232e-18     converged.

+------------------------------------+------------------+------------+------------------+
| Total wallclock time elapsed       |      68.6s     0 |      68.6s |      68.6s    27 |
|                                    |                  |                               |
| Section                | no. calls |   min time  rank |   avg time |   max time  rank |
+------------------------------------+------------------+------------+------------------+
| NavierStokes::solve    |       150 |     14.59s    13 |     14.59s |      14.6s     0 |
+------------------------------------+------------------+------------+------------------+
```

**ILU including damping terms:**
 ```

Time step #150, advancing from t_n-1 = 1.49e-05 to t = 1.5e-05 (dt = 1e-07).

   NL Resid u  NL Resid p     Prec Upd     Increm u   Increm p   Lin Iter     Lin Res
   __________________________________________________________________________________
   3.224e-04   1.136e-17        ---        1.30e-03   1.47e+02      15       3.20e-07
   3.201e-07   2.879e-12        ---        5.18e-06   4.73e+01      28       2.35e-10
   2.355e-10   2.958e-15        ---        1.57e-09   3.52e-03      27       4.09e-13
   4.088e-13   6.714e-18     converged.

+------------------------------------+------------------+------------+------------------+
| Total wallclock time elapsed       |     64.37s    24 |     64.38s |     64.38s    13 |
|                                    |                  |                               |
| Section                | no. calls |   min time  rank |   avg time |   max time  rank |
+------------------------------------+------------------+------------+------------------+
| NavierStokes::solve    |       150 |     12.01s     6 |     12.01s |     12.02s     0 |
+------------------------------------+------------------+------------+------------------+
 ```

**AMG original:**
```
Time step #150, advancing from t_n-1 = 1.49e-05 to t = 1.5e-05 (dt = 1e-07).

   NL Resid u  NL Resid p     Prec Upd     Increm u   Increm p   Lin Iter     Lin Res
   __________________________________________________________________________________
   3.224e-04   2.683e-17        ---        1.30e-03   1.47e+02      12       2.98e-07
   2.977e-07   2.809e-12        ---        5.22e-06   4.86e+01      25       2.21e-10
   2.215e-10   1.427e-14        ---        7.09e-09   3.41e-03      19       4.43e-13
   4.429e-13   4.067e-17     converged.
```

**AMG  including damping terms::**
```
Time step #150, advancing from t_n-1 = 1.49e-05 to t = 1.5e-05 (dt = 1e-07). 

   NL Resid u  NL Resid p     Prec Upd     Increm u   Increm p   Lin Iter     Lin Res
   __________________________________________________________________________________
   3.224e-04   7.119e-17        ---        1.30e-03   1.47e+02      13       3.02e-07
   3.020e-07   9.010e-12        ---        6.17e-06   4.82e+01      25       2.93e-10
   2.925e-10   2.571e-14        ---        1.09e-08   4.93e-03      26       4.35e-13
   4.345e-13   3.454e-17     converged.
```