### PR TITLE
Add missing `deal.II/include`

### DIFF
--- a/source/level_set_okz_preconditioner.cc
+++ b/source/level_set_okz_preconditioner.cc
@@ -17,6 +17,8 @@
 
 #include <deal.II/fe/fe_values.h>
 
+#include <deal.II/lac/trilinos_sparsity_pattern.h>
+
 #include <deal.II/matrix_free/fe_evaluation.h>
 #include <deal.II/matrix_free/matrix_free.h>
 


### PR DESCRIPTION
I've added a missing `deal.II/include` path. Otherwise, I got the following compile error:
```bash
[ 10%] Building CXX object CMakeFiles/adaflo.dir/source/level_set_okz_preconditioner.cc.o
[  0%] Building CXX object CMakeFiles/adaflo.dir/source/level_set_okz_compute_curvature.cc.o
/__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/source/level_set_okz_preconditioner.cc: In function ‘void initialize_projection_matrix(const dealii::MatrixFree<dim, Number, VectorizedArrayType>&, const dealii::AffineConstraints<number>&, unsigned int, unsigned int, const Number&, const Number&, const dealii::AlignedVector<Number>&, BlockMatrixExtension&, BlockILUExtension&)’:
/__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/source/level_set_okz_preconditioner.cc:95:39: error: ‘csp’ has incomplete type
   95 |     TrilinosWrappers::SparsityPattern csp;
      |                                       ^~~
In file included from /__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/include/adaflo/block_matrix_extension.h:22,
                 from /__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/include/adaflo/level_set_okz_preconditioner.h:22,
                 from /__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/source/level_set_okz_preconditioner.cc:23:
/usr/local/include/deal.II/lac/trilinos_sparse_matrix.h:67:9: note: forward declaration of ‘class dealii::TrilinosWrappers::SparsityPattern’
   67 |   class SparsityPattern;
      |         ^~~~~~~~~~~~~~~
/__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/source/level_set_okz_preconditioner.cc:95:39: error: ‘csp’ has incomplete type
   95 |     TrilinosWrappers::SparsityPattern csp;
      |                                       ^~~
In file included from /__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/include/adaflo/block_matrix_extension.h:22,
                 from /__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/include/adaflo/level_set_okz_preconditioner.h:22,
                 from /__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/source/level_set_okz_preconditioner.cc:23:
/usr/local/include/deal.II/lac/trilinos_sparse_matrix.h:67:9: note: forward declaration of ‘class dealii::TrilinosWrappers::SparsityPattern’
   67 |   class SparsityPattern;
      |         ^~~~~~~~~~~~~~~
/__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/source/level_set_okz_preconditioner.cc: In instantiation of ‘void initialize_projection_matrix(const dealii::MatrixFree<dim, Number, VectorizedArrayType>&, const dealii::AffineConstraints<number>&, unsigned int, unsigned int, const Number&, const Number&, const dealii::AlignedVector<Number>&, BlockMatrixExtension&, BlockILUExtension&) [with int dim = 1; Number = double; VectorizedArrayType = dealii::VectorizedArray<double, 2>]’:
/__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/source/level_set_okz_preconditioner.cc:191:78:   required from here
/__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/source/level_set_okz_preconditioner.cc:95:39: error: ‘dealii::TrilinosWrappers::SparsityPattern csp’ has incomplete type
   95 |     TrilinosWrappers::SparsityPattern csp;
      |                                       ^~~
/__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/source/level_set_okz_preconditioner.cc: In instantiation of ‘void initialize_projection_matrix(const dealii::MatrixFree<dim, Number, VectorizedArrayType>&, const dealii::AffineConstraints<number>&, unsigned int, unsigned int, const Number&, const Number&, const dealii::AlignedVector<Number>&, BlockMatrixExtension&, BlockILUExtension&) [with int dim = 2; Number = double; VectorizedArrayType = dealii::VectorizedArray<double, 2>]’:
/__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/source/level_set_okz_preconditioner.cc:203:78:   required from here
/__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/source/level_set_okz_preconditioner.cc:95:39: error: ‘dealii::TrilinosWrappers::SparsityPattern csp’ has incomplete type
/__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/source/level_set_okz_preconditioner.cc: In instantiation of ‘void initialize_projection_matrix(const dealii::MatrixFree<dim, Number, VectorizedArrayType>&, const dealii::AffineConstraints<number>&, unsigned int, unsigned int, const Number&, const Number&, const dealii::AlignedVector<Number>&, BlockMatrixExtension&, BlockILUExtension&) [with int dim = 3; Number = double; VectorizedArrayType = dealii::VectorizedArray<double, 2>]’:
/__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/source/level_set_okz_preconditioner.cc:215:78:   required from here
/__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/source/level_set_okz_preconditioner.cc:95:39: error: ‘dealii::TrilinosWrappers::SparsityPattern csp’ has incomplete type
In file included from /usr/include/c++/9/functional:59,
                 from /usr/include/boost/pool/pool.hpp:15,
                 from /usr/include/boost/pool/singleton_pool.hpp:25,
                 from /usr/include/boost/pool/pool_alloc.hpp:78,
                 from /usr/include/adolc/adtl.h:32,
                 from /usr/local/include/deal.II/differentiation/ad/adolc_math.h:24,
                 from /usr/local/include/deal.II/base/numbers.h:136,
                 from /usr/local/include/deal.II/base/config.h:513,
                 from /usr/local/include/deal.II/dofs/dof_tools.h:20,
                 from /__w/MeltPoolDG-dev/MeltPoolDG-dev/adaflo/source/level_set_okz_preconditioner.cc:16:
/usr/include/c++/9/bits/std_function.h: At global scope:
/usr/include/c++/9/bits/std_function.h:667:7: error: ‘std::function<_Res(_ArgTypes ...)>::function(_Functor) [with _Functor = initialize_projection_matrix(const dealii::MatrixFree<dim, Number, VectorizedArrayType>&, const dealii::AffineConstraints<number>&, unsigned int, unsigned int, const Number&, const Number&, const dealii::AlignedVector<Number>&, BlockMatrixExtension&, BlockILUExtension&) [with int dim = 1; Number = double; VectorizedArrayType = dealii::VectorizedArray<double, 2>]::<lambda(const auto:[47](https://github.com/MeltPoolDG/MeltPoolDG-dev/runs/5293577325?check_suite_focus=true#step:5:47)&, auto:[48](https://github.com/MeltPoolDG/MeltPoolDG-dev/runs/5293577325?check_suite_focus=true#step:5:48)&, const auto:[49](https://github.com/MeltPoolDG/MeltPoolDG-dev/runs/5293577325?check_suite_focus=true#step:5:49)&, auto:[50](https://github.com/MeltPoolDG/MeltPoolDG-dev/runs/5293577325?check_suite_focus=true#step:5:50))>; <template-parameter-2-2> = void; <template-parameter-2-3> = void; _Res = void; _ArgTypes = {const dealii::MatrixFree<1, double, dealii::VectorizedArray<double, 2> >&, std::shared_ptr<dealii::Threads::ThreadLocalStorage<AssemblyData::Data> >&, const unsigned int&, const std::pair<unsigned int, unsigned int>&}]’, declared using local type ‘initialize_projection_matrix(const dealii::MatrixFree<dim, Number, VectorizedArrayType>&, const dealii::AffineConstraints<number>&, unsigned int, unsigned int, const Number&, const Number&, const dealii::AlignedVector<Number>&, BlockMatrixExtension&, BlockILUExtension&) [with int dim = 1; Number = double; VectorizedArrayType = dealii::VectorizedArray<double, 2>]::<lambda(const auto:47&, auto:48&, const auto:49&, auto:50)>’, is used but never defined [-fpermissive]
  667 |       function<_Res(_ArgTypes...)>::
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/9/bits/std_function.h:667:7: error: ‘std::function<_Res(_ArgTypes ...)>::function(_Functor) [with _Functor = initialize_projection_matrix(const dealii::MatrixFree<dim, Number, VectorizedArrayType>&, const dealii::AffineConstraints<number>&, unsigned int, unsigned int, const Number&, const Number&, const dealii::AlignedVector<Number>&, BlockMatrixExtension&, BlockILUExtension&) [with int dim = 2; Number = double; VectorizedArrayType = dealii::VectorizedArray<double, 2>]::<lambda(const auto:47&, auto:48&, const auto:49&, auto:50)>; <template-parameter-2-2> = void; <template-parameter-2-3> = void; _Res = void; _ArgTypes = {const dealii::MatrixFree<2, double, dealii::VectorizedArray<double, 2> >&, std::shared_ptr<dealii::Threads::ThreadLocalStorage<AssemblyData::Data> >&, const unsigned int&, const std::pair<unsigned int, unsigned int>&}]’, declared using local type ‘initialize_projection_matrix(const dealii::MatrixFree<dim, Number, VectorizedArrayType>&, const dealii::AffineConstraints<number>&, unsigned int, unsigned int, const Number&, const Number&, const dealii::AlignedVector<Number>&, BlockMatrixExtension&, BlockILUExtension&) [with int dim = 2; Number = double; VectorizedArrayType = dealii::VectorizedArray<double, 2>]::<lambda(const auto:47&, auto:48&, const auto:49&, auto:50)>’, is used but never defined [-fpermissive]
/usr/include/c++/9/bits/std_function.h:667:7: error: ‘std::function<_Res(_ArgTypes ...)>::function(_Functor) [with _Functor = initialize_projection_matrix(const dealii::MatrixFree<dim, Number, VectorizedArrayType>&, const dealii::AffineConstraints<number>&, unsigned int, unsigned int, const Number&, const Number&, const dealii::AlignedVector<Number>&, BlockMatrixExtension&, BlockILUExtension&) [with int dim = 3; Number = double; VectorizedArrayType = dealii::VectorizedArray<double, 2>]::<lambda(const auto:47&, auto:48&, const auto:49&, auto:50)>; <template-parameter-2-2> = void; <template-parameter-2-3> = void; _Res = void; _ArgTypes = {const dealii::MatrixFree<3, double, dealii::VectorizedArray<double, 2> >&, std::shared_ptr<dealii::Threads::ThreadLocalStorage<AssemblyData::Data> >&, const unsigned int&, const std::pair<unsigned int, unsigned int>&}]’, declared using local type ‘initialize_projection_matrix(const dealii::MatrixFree<dim, Number, VectorizedArrayType>&, const dealii::AffineConstraints<number>&, unsigned int, unsigned int, const Number&, const Number&, const dealii::AlignedVector<Number>&, BlockMatrixExtension&, BlockILUExtension&) [with int dim = 3; Number = double; VectorizedArrayType = dealii::VectorizedArray<double, 2>]::<lambda(const auto:47&, auto:48&, const auto:49&, auto:50)>’, is used but never defined [-fpermissive]
make[3]: *** [CMakeFiles/adaflo.dir/build.make:63: CMakeFiles/adaflo.dir/source/level_set_okz_preconditioner.cc.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/Makefile2:292: CMakeFiles/adaflo.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:299: CMakeFiles/adaflo.dir/rule] Error 2
make: *** [Makefile:1[55](https://github.com/MeltPoolDG/MeltPoolDG-dev/runs/5293577325?check_suite_focus=true#step:5:55): adaflo] Error 2
```

Unfortunately, I did not find out which of the latest deal.II PRs is responsible for the inconsistency. 