### PR TITLE
Add getter function for `system_rhs`

### DIFF
--- a/include/adaflo/navier_stokes.h
+++ b/include/adaflo/navier_stokes.h
@@ -184,7 +184,7 @@ public:
   }
 
   const LinearAlgebra::distributed::BlockVector<double> &
-  get_rhs() const
+  get_system_rhs() const
   {
     return system_rhs;
   }

--- a/include/adaflo/navier_stokes.h
+++ b/include/adaflo/navier_stokes.h
@@ -183,6 +183,12 @@ public:
     return navier_stokes_matrix;
   }
 
+  const LinearAlgebra::distributed::BlockVector<double> &
+  get_rhs() const
+  {
+    return system_rhs;
+  }
+
   bool
   get_update_preconditioner() const
   {


### PR DESCRIPTION
This PR introduces a getter function for `system_rhs`. We use this vector in `MeltPoolDG` to analyze the behavior when the Navier-Stokes solver fails.