### PR TITLE
Add `set_time_step` function

### DIFF
--- a/include/adaflo/navier_stokes.h
+++ b/include/adaflo/navier_stokes.h
@@ -226,8 +226,6 @@ public:
 
 private:
   void
-  set_time_step_weight(const double new_weight);
-  void
   apply_boundary_conditions();
   double
   compute_residual();

--- a/include/adaflo/time_stepping.h
+++ b/include/adaflo/time_stepping.h
@@ -137,10 +137,10 @@ private:
   const double min_step_val;     // [i] minimum value of the time increment
   double       current_step_val; // [m] current value of the time increment;
                                  //     initialized in the constructor by start_step_val
-                           //     can be modified in set_desired_time_step(desired_value)
-                           //     fulfilling the criteria
-                           //         - 0.5 * step_size_prev <= current_step_val <=
-                           //         2*step_size_prev
+  //     can be modified in set_desired_time_step(desired_value)
+  //     fulfilling the criteria
+  //         - 0.5 * step_size_prev <= current_step_val <=
+  //         2*step_size_prev
   //         - min_step_val <= current_step_val <= max_step_val
   double last_step_val; // [m] constructor and restart() sets this parameter to zero.
                         //     next() sets this parameter equal to current_step_val

--- a/include/adaflo/time_stepping.h
+++ b/include/adaflo/time_stepping.h
@@ -113,6 +113,8 @@ public:
   void
   set_final_time(double);
   void
+  set_desired_time_step(double);
+  void
   set_time_step(double);
   std::string
   name() const;
@@ -135,18 +137,19 @@ private:
   const double min_step_val;     // [i] minimum value of the time increment
   double       current_step_val; // [m] current value of the time increment;
                                  //     initialized in the constructor by start_step_val
-                                 //     can be modified in set_time_step(desired_value)
-                                 //     fulfilling the criteria
-                                 //         - 0.5 * step_size_prev <= current_step_val <=
-                                 //         2*step_size_prev
+                           //     can be modified in set_desired_time_step(desired_value)
+                           //     fulfilling the criteria
+                           //         - 0.5 * step_size_prev <= current_step_val <=
+                           //         2*step_size_prev
   //         - min_step_val <= current_step_val <= max_step_val
-  double last_step_val;  // [m] constructor and restart() sets this parameter to zero.
-                         //     next() sets this parameter equal to current_step_val
-                         //     (corresponding to the previous time increment)
-  double step_val;       // [m] current value of the time increment; m]
-                         //     - initialized in the constructor by start_step_val
-                         //     - changed in set_time_step to be equal to current_step_val
-                         //     @todo - ambiguous with current_step_val (?)
+  double last_step_val; // [m] constructor and restart() sets this parameter to zero.
+                        //     next() sets this parameter equal to current_step_val
+                        //     (corresponding to the previous time increment)
+  double
+    step_val; // [m] current value of the time increment; m]
+              //     - initialized in the constructor by start_step_val
+              //     - changed in set_desired_time_step to be equal to current_step_val
+              //     @todo - ambiguous with current_step_val (?)
   double weight_val;     // [m] 1/time_increment
                          //     - constructor: 1/start_step_val;
                          //     - next():      1/current_step_val

--- a/source/level_set_okz_advance_concentration.cc
+++ b/source/level_set_okz_advance_concentration.cc
@@ -507,7 +507,7 @@ template <int dim>
 void
 LevelSetOKZSolverAdvanceConcentration<dim>::advance_concentration(const double dt)
 {
-  this->time_stepping.set_time_step(dt);
+  this->time_stepping.set_desired_time_step(dt);
   this->time_stepping.next();
 
   if (global_omega_diameter == 0.0)

--- a/source/level_set_okz_reinitialization.cc
+++ b/source/level_set_okz_reinitialization.cc
@@ -264,7 +264,7 @@ LevelSetOKZSolverReinitialization<dim>::reinitialize(
   const unsigned int               diff_steps,
   const std::function<void(bool)> &compute_normal)
 {
-  this->time_stepping.set_time_step(dt);
+  this->time_stepping.set_desired_time_step(dt);
 
   // This function assembles and solves for a given profile using the approach
   // described in the paper by Olsson, Kreiss, and Zahedi.

--- a/source/time_stepping.cc
+++ b/source/time_stepping.cc
@@ -235,8 +235,18 @@ TimeStepping::at_tick(const double tick) const
 }
 
 
+
 void
-TimeStepping::set_time_step(const double desired_value)
+TimeStepping::set_time_step(const double value)
+{
+  current_step_val = value;
+  step_val         = current_step_val;
+}
+
+
+
+void
+TimeStepping::set_desired_time_step(const double desired_value)
 {
   // We take into account the first iteration regarding to the
   // previous used time step

--- a/source/two_phase_base.cc
+++ b/source/two_phase_base.cc
@@ -611,7 +611,7 @@ TwoPhaseBaseAlgorithm<dim>::set_adaptive_time_step(const double norm_velocity) c
   // hand this step to the timer stepper. The time stepper will make sure that
   // the time step does not change too rapidly from one iteration to the next
   // and also be within the bounds set in the parameter file.
-  time_stepping.set_time_step(new_time_step);
+  time_stepping.set_desired_time_step(new_time_step);
 }
 
 


### PR DESCRIPTION
This PR introduces a `set_time_step` function to obtain external access of the time step size. To this end, I renamed the existing `set_time_step` function to `set_desired_time_step`, since the existing function potentially modifies the time step size to fulfill some restrictions.