### PR TITLE
`FlowBaseAlgorithm::advance_time_step()`: add number of linear iterations as return value

### DIFF
--- a/include/adaflo/flow_base_algorithm.h
+++ b/include/adaflo/flow_base_algorithm.h
@@ -117,10 +117,10 @@ struct FlowBaseAlgorithm
 
   /**
    * Performs one complete time step of the problem, including the solution of
-   * each associated field. Returns the number of accumulated linear
-   * iterations during the time step.
+   * each associated field. Returns the number of nonlinear and the accumulated
+   * linear iterations during the time step.
    */
-  virtual unsigned int
+  virtual std::pair<unsigned int, unsigned int>
   advance_time_step() = 0;
 
   /**

--- a/include/adaflo/level_set_base.h
+++ b/include/adaflo/level_set_base.h
@@ -43,7 +43,7 @@ public:
   virtual void
   initialize_data_structures();
 
-  virtual unsigned int
+  virtual std::pair<unsigned int, unsigned int>
   advance_time_step(); // perform one time step
 
   // write whole solution to file

--- a/include/adaflo/navier_stokes.h
+++ b/include/adaflo/navier_stokes.h
@@ -112,9 +112,9 @@ public:
 
   void
   init_time_advance(const bool print_time_info = true);
-  unsigned int
+  std::pair<unsigned int, unsigned int>
   evaluate_time_step();
-  virtual unsigned int
+  virtual std::pair<unsigned int, unsigned int>
   advance_time_step();
 
   virtual void
@@ -203,7 +203,7 @@ public:
   // Solves the nonlinear Navier-Stokes system by a Newton or Newton-like
   // iteration. This function expects that the initial residual is passed into
   // the function as an argument
-  unsigned int
+  std::pair<unsigned int, unsigned int>
   solve_nonlinear_system(const double initial_residual);
 
   // return an estimate of the total memory consumption

--- a/include/adaflo/phase_field.h
+++ b/include/adaflo/phase_field.h
@@ -57,7 +57,7 @@ public:
   distribute_dofs();
   virtual void
   initialize_data_structures();
-  virtual unsigned int
+  virtual std::pair<unsigned int, unsigned int>
   advance_time_step();
 
   void

--- a/source/level_set_base.cc
+++ b/source/level_set_base.cc
@@ -185,7 +185,7 @@ LevelSetBaseAlgorithm<dim>::initialize_data_structures()
 
 
 template <int dim>
-unsigned int
+std::pair<unsigned int, unsigned int>
 LevelSetBaseAlgorithm<dim>::advance_time_step()
 {
   // advance the time in the time stepping scheme. The Navier--Stokes class
@@ -241,7 +241,7 @@ LevelSetBaseAlgorithm<dim>::advance_time_step()
           this->pcout << "/" << convergence.first << "] " << std::flush;
         }
       */
-      return step;
+      return {step, 0};
     }
   // do not iterate, just do an extrapolated value on the concentration
   else

--- a/source/navier_stokes.cc
+++ b/source/navier_stokes.cc
@@ -739,7 +739,7 @@ NavierStokes<dim>::init_time_advance(const bool print_time_info)
 
 
 template <int dim>
-unsigned int
+std::pair<unsigned int, unsigned int>
 NavierStokes<dim>::advance_time_step()
 {
   init_time_advance();
@@ -749,7 +749,7 @@ NavierStokes<dim>::advance_time_step()
 
 
 template <int dim>
-unsigned int
+std::pair<unsigned int, unsigned int>
 NavierStokes<dim>::evaluate_time_step()
 {
   const double initial_residual = compute_initial_residual(true);
@@ -813,7 +813,7 @@ NavierStokes<dim>::compute_initial_residual(const bool)
 
 
 template <int dim>
-unsigned int
+std::pair<unsigned int, unsigned int>
 NavierStokes<dim>::solve_nonlinear_system(const double initial_residual)
 {
   Timer        nl_timer;
@@ -1135,7 +1135,7 @@ NavierStokes<dim>::solve_nonlinear_system(const double initial_residual)
       std::cout.flags(flags);
     }
 
-  return step;
+  return {step + 1, n_tot_iterations};
 }
 
 

--- a/source/phase_field.cc
+++ b/source/phase_field.cc
@@ -461,7 +461,7 @@ PhaseFieldSolver<dim>::solve_cahn_hilliard()
 
 
 template <int dim>
-unsigned int
+std::pair<unsigned int, unsigned int>
 PhaseFieldSolver<dim>::advance_time_step()
 {
   this->init_time_advance();


### PR DESCRIPTION
This PR extends the return value of `FlowBaseAlgorithm::advance_time_step()` by the number of linear iterations. This is helpful in the context of MeltPoolDG to also record the number of linear iterations of the `NavierStokesSolver`. 