### PR TITLE
Initialize number of linear iterations of `NavierStokes::solver_control_strong` to 0

### DIFF
--- a/source/navier_stokes.cc
+++ b/source/navier_stokes.cc
@@ -576,7 +576,9 @@ NavierStokes<dim>::solve_system(const double linear_tolerance)
   // not succeed, throw the more powerful (but more expensive) solver at
   // it. Note that we use FGMRES for that case as there are inner iterations
   // which make the preconditioner non-linear
-  double residual = 1.;
+  double       residual    = 1.;
+  unsigned int iter_strong = 0;
+
   try
     {
       preconditioner.do_inner_solves = false;
@@ -625,7 +627,8 @@ NavierStokes<dim>::solve_system(const double linear_tolerance)
           catch (const SolverControl::NoConvergence &)
             {}
 
-          residual = solver_control_strong.last_value();
+          iter_strong = solver_control_strong.last_step();
+          residual    = solver_control_strong.last_value();
         }
       else
         residual = solver_control_simple.last_value();
@@ -639,8 +642,7 @@ NavierStokes<dim>::solve_system(const double linear_tolerance)
 
   timer->leave_subsection();
 
-  return std::pair<unsigned int, double>(solver_control_simple.last_step() +
-                                           solver_control_strong.last_step(),
+  return std::pair<unsigned int, double>(solver_control_simple.last_step() + iter_strong,
                                          residual);
 }
 


### PR DESCRIPTION
This PR suggests to initialize the default value of the number of linear iterations recorded by `solver_control_strong` to 0.

Previously, if the initially evaluated residual was 0 in a time step, this block https://github.com/kronbichler/adaflo/blob/6e1a28d2e5de937d95defd716994a761847ea1da/source/navier_stokes.cc#L605-L632
would have never been reached. This led to a recorded number of linear iterations from `solver_control_strong` of `numbers::invalid_unsigned_int` (default value of `SolverControl::last_step()`), which produced output like this:

```
   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
   ____________________________________________________________
   0.000e+00        ---        0.00e+00        -1       0.00e+00
   0.000e+00     converged.
```

With this PR, the output looks as follows:
```
   Nonlin Res     Prec Upd     Increment   Lin Iter     Lin Res
   ____________________________________________________________
   0.000e+00        ---        0.00e+00        0       0.00e+00
   0.000e+00     converged.
```

