### PR TITLE
Add missing curly braces to catch statement

### DIFF
--- a/source/navier_stokes_preconditioner.cc
+++ b/source/navier_stokes_preconditioner.cc
@@ -657,8 +657,10 @@ NavierStokesPreconditioner<dim>::vmult(
             }
         }
       catch (...)
-        Assert(false,
-               ExcMessage("Solver for velocity-velocity matrix did not converge."));
+        {
+          Assert(false,
+                 ExcMessage("Solver for velocity-velocity matrix did not converge."));
+        }
     }
   precond_timer.second[0] += time.wall_time();
 


### PR DESCRIPTION
This PR adds missing curly braces to a catch statement inside the `NavierStokesPreconditioner`. This issue was identified by the CI check of MeltPoolDG and led to a compile error.
