### PR TITLE
Remove global using namespace dealii

### DIFF
--- a/include/adaflo/navier_stokes.h
+++ b/include/adaflo/navier_stokes.h
@@ -333,7 +333,7 @@ namespace adaflo
 
 
 template <int dim>
-inline const FiniteElement<dim> &
+inline const dealii::FiniteElement<dim> &
 adaflo::NavierStokes<dim>::get_fe_u() const
 {
   return fe_u;
@@ -342,7 +342,7 @@ adaflo::NavierStokes<dim>::get_fe_u() const
 
 
 template <int dim>
-inline const FiniteElement<dim> &
+inline const dealii::FiniteElement<dim> &
 adaflo::NavierStokes<dim>::get_fe_p() const
 {
   // We get simpler code by using FESystem, but we want to pretend we have a
@@ -353,7 +353,7 @@ adaflo::NavierStokes<dim>::get_fe_p() const
 
 
 template <int dim>
-inline const DoFHandler<dim> &
+inline const dealii::DoFHandler<dim> &
 adaflo::NavierStokes<dim>::get_dof_handler_u() const
 {
   return dof_handler_u;
@@ -362,7 +362,7 @@ adaflo::NavierStokes<dim>::get_dof_handler_u() const
 
 
 template <int dim>
-inline const DoFHandler<dim> &
+inline const dealii::DoFHandler<dim> &
 adaflo::NavierStokes<dim>::get_dof_handler_p() const
 {
   return dof_handler_p;
@@ -371,7 +371,7 @@ adaflo::NavierStokes<dim>::get_dof_handler_p() const
 
 
 template <int dim>
-inline const AffineConstraints<double> &
+inline const dealii::AffineConstraints<double> &
 adaflo::NavierStokes<dim>::get_constraints_u() const
 {
   return constraints_u;
@@ -380,7 +380,7 @@ adaflo::NavierStokes<dim>::get_constraints_u() const
 
 
 template <int dim>
-inline AffineConstraints<double> &
+inline dealii::AffineConstraints<double> &
 adaflo::NavierStokes<dim>::modify_constraints_u()
 {
   return constraints_u;
@@ -389,7 +389,7 @@ adaflo::NavierStokes<dim>::modify_constraints_u()
 
 
 template <int dim>
-inline const AffineConstraints<double> &
+inline const dealii::AffineConstraints<double> &
 adaflo::NavierStokes<dim>::get_hanging_node_constraints_u() const
 {
   return hanging_node_constraints_u;
@@ -398,7 +398,7 @@ adaflo::NavierStokes<dim>::get_hanging_node_constraints_u() const
 
 
 template <int dim>
-inline const AffineConstraints<double> &
+inline const dealii::AffineConstraints<double> &
 adaflo::NavierStokes<dim>::get_constraints_p() const
 {
   return constraints_p;
@@ -407,7 +407,7 @@ adaflo::NavierStokes<dim>::get_constraints_p() const
 
 
 template <int dim>
-inline const AffineConstraints<double> &
+inline const dealii::AffineConstraints<double> &
 adaflo::NavierStokes<dim>::get_hanging_node_constraints_p() const
 {
   return hanging_node_constraints_p;
@@ -416,7 +416,7 @@ adaflo::NavierStokes<dim>::get_hanging_node_constraints_p() const
 
 
 template <int dim>
-inline AffineConstraints<double> &
+inline dealii::AffineConstraints<double> &
 adaflo::NavierStokes<dim>::modify_constraints_p()
 {
   return constraints_p;
@@ -436,9 +436,9 @@ adaflo::NavierStokes<dim>::get_parameters() const
 template <int dim>
 inline void
 adaflo::NavierStokes<dim>::set_face_average_density(
-  const typename Triangulation<dim>::cell_iterator &cell,
-  const unsigned int                                face,
-  const double                                      density)
+  const typename dealii::Triangulation<dim>::cell_iterator &cell,
+  const unsigned int                                        face,
+  const double                                              density)
 {
   preconditioner.set_face_average_density(cell, face, density);
 }

--- a/include/adaflo/navier_stokes_matrix.h
+++ b/include/adaflo/navier_stokes_matrix.h
@@ -291,7 +291,7 @@ namespace adaflo
 
 // access to density and viscosity fields
 template <int dim>
-inline const VectorizedArray<double> *
+inline const dealii::VectorizedArray<double> *
 adaflo::NavierStokesMatrix<dim>::begin_densities(const unsigned int macro_cell) const
 {
   AssertIndexRange(macro_cell, matrix_free->n_cell_batches());
@@ -304,7 +304,7 @@ adaflo::NavierStokesMatrix<dim>::begin_densities(const unsigned int macro_cell) 
 
 
 template <int dim>
-inline VectorizedArray<double> *
+inline dealii::VectorizedArray<double> *
 adaflo::NavierStokesMatrix<dim>::begin_densities(const unsigned int macro_cell)
 {
   AssertIndexRange(macro_cell, matrix_free->n_cell_batches());
@@ -317,7 +317,7 @@ adaflo::NavierStokesMatrix<dim>::begin_densities(const unsigned int macro_cell)
 
 
 template <int dim>
-inline const VectorizedArray<double> *
+inline const dealii::VectorizedArray<double> *
 adaflo::NavierStokesMatrix<dim>::begin_viscosities(const unsigned int macro_cell) const
 {
   AssertIndexRange(macro_cell, matrix_free->n_cell_batches());
@@ -330,7 +330,7 @@ adaflo::NavierStokesMatrix<dim>::begin_viscosities(const unsigned int macro_cell
 
 
 template <int dim>
-inline VectorizedArray<double> *
+inline dealii::VectorizedArray<double> *
 adaflo::NavierStokesMatrix<dim>::begin_viscosities(const unsigned int macro_cell)
 {
   AssertIndexRange(macro_cell, matrix_free->n_cell_batches());
@@ -343,7 +343,7 @@ adaflo::NavierStokesMatrix<dim>::begin_viscosities(const unsigned int macro_cell
 
 
 template <int dim>
-inline const VectorizedArray<double> *
+inline const dealii::VectorizedArray<double> *
 adaflo::NavierStokesMatrix<dim>::begin_damping_coeff(const unsigned int macro_cell) const
 {
   AssertIndexRange(macro_cell, matrix_free->n_cell_batches());
@@ -357,7 +357,7 @@ adaflo::NavierStokesMatrix<dim>::begin_damping_coeff(const unsigned int macro_ce
 
 
 template <int dim>
-inline VectorizedArray<double> *
+inline dealii::VectorizedArray<double> *
 adaflo::NavierStokesMatrix<dim>::begin_damping_coeff(const unsigned int macro_cell)
 {
   AssertIndexRange(macro_cell, matrix_free->n_cell_batches());

--- a/include/adaflo/parameters.h
+++ b/include/adaflo/parameters.h
@@ -23,13 +23,9 @@
 #include <fstream>
 #include <iostream>
 
-using namespace dealii;
-
-
 namespace adaflo
 {
   using namespace dealii;
-
 
   struct FlowParameters
   {

--- a/include/adaflo/sharp_interface_util.h
+++ b/include/adaflo/sharp_interface_util.h
@@ -864,8 +864,8 @@ namespace adaflo
         const auto [points, weights] =
           [&]() -> std::tuple<std::vector<Point<dim>>, std::vector<double>> {
           // determine points and cells of aux surface triangulation
-          std::vector<Point<dim>>          surface_vertices;
-          std::vector<::CellData<dim - 1>> surface_cells;
+          std::vector<Point<dim>>        surface_vertices;
+          std::vector<CellData<dim - 1>> surface_cells;
 
           // run square/cube marching algorithm
           mc.process_cell(cell, ls_vector, 0.0, surface_vertices, surface_cells);


### PR DESCRIPTION
This PR removes a remaining global `using namespace dealii` statement.

Follow-up to #88 