### PR TITLE
SparsityPattern::reinit(): specify all the default arguments

### DIFF
--- a/source/level_set_okz_preconditioner.cc
+++ b/source/level_set_okz_preconditioner.cc
@@ -100,7 +100,8 @@ adaflo::initialize_projection_matrix(
     csp.reinit(dof_handler.locally_owned_dofs(),
                dof_handler.locally_owned_dofs(),
                relevant_dofs,
-               dof_handler.get_mpi_communicator());
+               dof_handler.get_mpi_communicator(),
+               0);
     std::vector<types::global_dof_index> local_dof_indices(fe.dofs_per_cell);
 
     for (const auto &cell : dof_handler.active_cell_iterators())

--- a/source/navier_stokes_preconditioner.cc
+++ b/source/navier_stokes_preconditioner.cc
@@ -1192,7 +1192,8 @@ adaflo::NavierStokesPreconditioner<dim>::initialize_matrices(
     csp.reinit(dof_handler_u.locally_owned_dofs(),
                dof_handler_u.locally_owned_dofs(),
                constraints_u.get_local_lines(),
-               triangulation.get_mpi_communicator());
+               triangulation.get_mpi_communicator(),
+               0);
 
     if (parameters.precondition_velocity == FlowParameters::u_amg ||
         parameters.precondition_velocity == FlowParameters::u_ilu)
@@ -1299,7 +1300,8 @@ adaflo::NavierStokesPreconditioner<dim>::initialize_matrices(
     TrilinosWrappers::SparsityPattern csp(dof_handler_p.locally_owned_dofs(),
                                           dof_handler_p.locally_owned_dofs(),
                                           constraints_p.get_local_lines(),
-                                          triangulation.get_mpi_communicator());
+                                          triangulation.get_mpi_communicator(),
+                                          0);
 
     if (parameters.precondition_velocity != FlowParameters::u_amg_linear ||
         parameters.augmented_taylor_hood)
@@ -1336,7 +1338,8 @@ adaflo::NavierStokesPreconditioner<dim>::initialize_matrices(
         TrilinosWrappers::SparsityPattern    sparsity(dof_handler_p.locally_owned_dofs(),
                                                    dof_handler_p.locally_owned_dofs(),
                                                    constraints_p.get_local_lines(),
-                                                   triangulation.get_mpi_communicator());
+                                                   triangulation.get_mpi_communicator(),
+                                                   0);
         std::vector<types::global_dof_index> local_dof_indices(fe_p.dofs_per_cell);
         std::vector<types::global_dof_index> neigh_dof_indices(fe_p.dofs_per_cell);
         std::vector<types::global_dof_index> const_dof_index(1);

--- a/source/phase_field.cc
+++ b/source/phase_field.cc
@@ -250,7 +250,8 @@ adaflo::PhaseFieldSolver<dim>::create_cahn_hilliard_preconditioner()
       TrilinosWrappers::SparsityPattern csp(this->dof_handler.locally_owned_dofs(),
                                             this->dof_handler.locally_owned_dofs(),
                                             relevant_dofs,
-                                            this->triangulation.get_mpi_communicator());
+                                            this->triangulation.get_mpi_communicator(),
+                                            0);
       DoFTools::make_sparsity_pattern(this->dof_handler, csp);
       csp.compress();
       preconditioner_matrix.reinit(csp);


### PR DESCRIPTION
I got a weird linker error:

```
./applications/mp-melt-pool/mp-melt-pool: symbol lookup error: /workspace/adaflo/build_release/libadaflo.so: undefined symbol: _ZN6dealii16TrilinosWrappers15SparsityPatternC1ERKNS_8IndexSetES4_S4_P19ompi_communicator_t
```

The issue could be resolved by explicitly specifying all default arguments of the constructor. It appears to be related to the changes introduced in https://github.com/dealii/dealii/pull/19106.

My current understanding is that the problem arose because only some of the default arguments were specified, rather than either none or all of them, leading to a mismatch with the available constructor symbols at runtime.